### PR TITLE
Fix readme linux cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The node consists of the following elements:</p>
 >git submodule update --init --recursive
 >mkdir build
 >cd build
->cmake -DCMAKE_BUILD_TYPE=Release -A x64 ..
+>cmake -DCMAKE_BUILD_TYPE=Release ..
 >make
 
 <h2>System requirements:</h2>

--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ The node consists of the following elements:</p>
 
 <h2>Build dependencies</h2>
 <ul>
-<li>Boost 1.68 and higher static prebuild, compiler with C++17 support</li>
-</ul>
+<li><a href="https://www.boost.org/users/history/version_1_68_0.html">Boost 1.68</a> or newest static prebuild</li>
+<li>Compiler with C++17 support</li>
+<li><a href="https://cmake.org/download/">Cmake 3.11</a> or newest</li>
+<li> Requirements fo building <a href="https://thrift.apache.org/docs/install/">Apache Thrift</a></li>
+<li><a href="https://github.com/jedisct1/libsodium">libsodium</a></li>
+<li>The building Berkeley DB distribution uses the Free Software Foundation's autoconf and libtool tools to build on UNIX platforms.</li>
 
-<h2>How to Build</h2>
+On Windows<br/>
+
+It is necessary to run in the terminal, which sets the environment variables for building a Visual Studio project
 
 >```sh
 >git clone https://github.com/CREDITSCOM/node.git
@@ -39,8 +45,17 @@ The node consists of the following elements:</p>
 >git submodule update --init --recursive
 >mkdir build
 >cd build
+>cmake -DCMAKE_BUILD_TYPE=Release -A x64 ..
+>cmake --build . --target ALL_BUILD --config Release
+On Linux<br/>
+>```sh
+>git clone https://github.com/CREDITSCOM/node.git
+>cd node
+>git submodule update --init --recursive
+>mkdir build
+>cd build
 >cmake -DCMAKE_BUILD_TYPE=Release ..
->make
+>make -j4
 
 <h2>System requirements:</h2>
 <h4>Minimum system requirements:</h4>


### PR DESCRIPTION
### Description of the Change
bug bounty have not been updated with compilation instructions in README.me file. So cmake line do not work with linux and also dependency section is now better with latest commits. It would be usefull to update it for bug bounty users.

### Release Notes
- get dependency and compile instructions from master branch to update on bug_bounty branch.
