### PR TITLE
Port shutdown / Ctrl+C handling

### DIFF
--- a/api/include/dumbcv.hpp
+++ b/api/include/dumbcv.hpp
@@ -2,7 +2,9 @@
 #define DUMBCV_HPP
 
 #include <atomic>
+#include <condition_variable>
 #include <map>
+#include <mutex>
 #include <lib/system/common.hpp>
 #include <csdb/transaction.hpp>
 

--- a/client/src/peer.cpp
+++ b/client/src/peer.cpp
@@ -138,6 +138,7 @@ bool Peer::onRun(const char*) {
     }
 
     cslog() << "Node stopped";
+    node_->stop();   // idempotent; ensures stop ordering even if run() returned via a non-stop path
     cslog() << "Destroying Node";
     node_->destroy();
     node_.reset(nullptr);

--- a/csnode/include/csnode/blockchain.hpp
+++ b/csnode/include/csnode/blockchain.hpp
@@ -85,6 +85,8 @@ public:
 
     bool isGood() const;
 
+    void flushIndexes();
+
     // return unique id of database if at least one unique block has written, otherwise (only genesis block) 0
     uint64_t uuid() const;
 
@@ -168,6 +170,7 @@ public:
 
     // storage adaptor
     void close();
+    void requestStop() { stop_ = true; }
     bool getTransaction(const csdb::Address& addr, const int64_t& innerId, csdb::Transaction& result) const;
     void arrangeBlocksInCache();
 

--- a/csnode/include/csnode/poolsynchronizer.hpp
+++ b/csnode/include/csnode/poolsynchronizer.hpp
@@ -1,6 +1,8 @@
 #ifndef POOLSYNCHRONIZER_HPP
 #define POOLSYNCHRONIZER_HPP
 
+#include <mutex>
+
 #include <csdb/pool.hpp>
 
 #include <csnode/blockchain.hpp>
@@ -23,6 +25,8 @@ public:
     void syncLastPool();
     void getBlockReply(PoolsBlock&& poolsBlock, const cs::PublicKey& sender);
     bool isSyncroStarted() const;
+
+    void stop();
 
     cs::Sequence getMaxNeighbourSequence();
     static const RoundNumber kRoundDifferentForSync = values::kDefaultMetaStorageMaxSize;
@@ -71,6 +75,7 @@ private:
     BlockChain* blockChain_;
 
     std::atomic<bool> isSyncroStarted_ = false;
+    std::atomic<bool> stopped_ = false;
 
     Sequence maxRequestedSequence_ = kWrongSequence;
     std::unordered_map<PublicKey, Sequence> neighbours_;

--- a/csnode/include/csnode/transactionsindex.hpp
+++ b/csnode/include/csnode/transactionsindex.hpp
@@ -26,6 +26,7 @@ public:
     void update(const csdb::Pool&);
     void invalidate();
     void close();
+    void flush();
 
     bool recreate() const;
 

--- a/csnode/src/blockchain.cpp
+++ b/csnode/src/blockchain.cpp
@@ -144,6 +144,11 @@ bool BlockChain::init(
     bool checkTrxIndexRecreate = true;
 
     csdb::Storage::OpenCallback progress = [&](const csdb::Storage::OpenProgress& progress) {
+        if (stop_) {
+            cslog() << kLogPrefix << "shutdown requested, aborting slow start at "
+                    << WithDelimiters(progress.poolsProcessed);
+            return true;
+        }
         if (checkTrxIndexRecreate) {
           checkTrxIndexRecreate = false;
           if (trxIndex_->recreate() && successfulQuickStart) {
@@ -195,6 +200,12 @@ bool BlockChain::init(
 
 bool BlockChain::isGood() const {
     return good_;
+}
+
+void BlockChain::flushIndexes() {
+    if (trxIndex_) {
+        trxIndex_->flush();
+    }
 }
 
 uint64_t BlockChain::uuid() const {

--- a/csnode/src/node.cpp
+++ b/csnode/src/node.cpp
@@ -167,9 +167,16 @@ bool Node::init() {
                 initialConfidants_,
                 cs::ConfigHolder::instance().config()->newBlockchainTopSeq())
         ) {
-            csinfo() << "Remove data for QUICK START";
-            cachesSerializationManager_.clear();
-
+            if (isStopRequested()) {
+                cslog() << "Init aborted by user; preserving QUICK START state.";
+                if (cachesSerializationManager_.save(0)) {
+                    blockChain_.flushIndexes();
+                    cslog() << "Saved interim QUICK START state to qs/0.";
+                }
+            } else {
+                csinfo() << "Remove data for QUICK START";
+                cachesSerializationManager_.clear();
+            }
             return false;
         }
         Consensus::TimeMinStage1 = blockChain_.getTimeMinStage1();
@@ -191,9 +198,16 @@ bool Node::init() {
             cs::ConfigHolder::instance().config()->getPathToDB(),
             &cachesSerializationManager_, initialConfidants_)
     ) {
-        csinfo() << "Remove data for QUICK START";
-        cachesSerializationManager_.clear();
-
+        if (isStopRequested()) {
+            cslog() << "Init aborted by user; preserving QUICK START state.";
+            if (cachesSerializationManager_.save(0)) {
+                blockChain_.flushIndexes();
+                cslog() << "Saved interim QUICK START state to qs/0.";
+            }
+        } else {
+            csinfo() << "Remove data for QUICK START";
+            cachesSerializationManager_.clear();
+        }
         return false;
     }
 
@@ -276,6 +290,10 @@ void Node::stop() {
     dumpKnownPeersToFile();
     EventReport::sendRunningStatus(*this, Running::Status::Stop);
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    if (poolSynchronizer_) {
+        poolSynchronizer_->stop();
+    }
 
     // stopping transport stops the node (see Node::run() method)
     transport_->stop();
@@ -3954,6 +3972,8 @@ void Node::requestStop() {
 }
 
 void Node::onStopRequested() {
+    blockChain_.requestStop();
+
     if (stopRequested_) {
         stop();
         return;
@@ -4239,12 +4259,9 @@ void Node::checkConsensusSettings(cs::Sequence seq, std::string& msg){
 }
 
 void Node::validateBlock(const csdb::Pool& block, bool* shouldStop) {
-    if (stopRequested_) {
-        *shouldStop = true;
-        return;
-    }
+    // user-cancel is honoured via BlockChain::init's OpenCallback; *shouldStop here means DataIntegrityError
     if (!blockValidator_->validateBlock(block,
-        cs::BlockValidator::ValidationLevel::hashIntergrity 
+        cs::BlockValidator::ValidationLevel::hashIntergrity
             | cs::BlockValidator::ValidationLevel::blockNum
             /*| cs::BlockValidator::ValidationLevel::smartStates*/
             /*| cs::BlockValidator::ValidationLevel::accountBalance*/,

--- a/csnode/src/poolsynchronizer.cpp
+++ b/csnode/src/poolsynchronizer.cpp
@@ -43,6 +43,9 @@ PoolSynchronizer::PoolSynchronizer(BlockChain* blockChain)
 }
 
 void PoolSynchronizer::sync(cs::RoundNumber roundNum, cs::RoundNumber difference) {
+    if (stopped_.load(std::memory_order_acquire)) {
+        return;
+    }
     if (neighbours_.empty()) {
         csdebug() << "SYNC: no actual neighbours to start sync";
         return;
@@ -105,6 +108,9 @@ void PoolSynchronizer::sync(cs::RoundNumber roundNum, cs::RoundNumber difference
 }
 
 void PoolSynchronizer::syncLastPool() {
+    if (stopped_.load(std::memory_order_acquire)) {
+        return;
+    }
     if (neighbours_.empty()) {
         csdebug() << "SYNC: (last pool) no actual neighbours to request the last block";
         return;
@@ -152,6 +158,9 @@ void PoolSynchronizer::manageSyncBlocks(cs::PoolsBlock&& poolsBlock) {
 }
 
 void PoolSynchronizer::getBlockReply(cs::PoolsBlock&& poolsBlock, const cs::PublicKey& sender) {
+    if (stopped_.load(std::memory_order_acquire)) {
+        return;
+    }
     csdebug() << "SYNC: Get Block Reply <<<<<<< : count: " << poolsBlock.size()
         << ", seqs: [" << poolsBlock.front().sequence()
         << ", " << poolsBlock.back().sequence() << "]";
@@ -170,6 +179,9 @@ bool PoolSynchronizer::isSyncroStarted() const {
 //
 
 void PoolSynchronizer::onTimeOut() {
+    if (stopped_.load(std::memory_order_acquire)) {
+        return;
+    }
     if (!isSyncroStarted_) {
         return;
     }
@@ -420,6 +432,18 @@ void PoolSynchronizer::synchroFinished() {
     csdebug() << "SYNC: Synchro finished";
 }
 
+void PoolSynchronizer::stop() {
+    bool expected = false;
+    if (!stopped_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        return;
+    }
+    timer_.stop();
+    isSyncroStarted_ = false;
+    synchroLog_.clear();
+    maxRequestedSequence_ = kWrongSequence;
+    cslog() << "SYNC: shutdown — pool synchronizer stopped";
+}
+
 void PoolSynchronizer::getSyncroMessage(const cs::PublicKey& sender, SyncroMessage msg) {
     if (cs::Conveyer::instance().currentRoundNumber() < Consensus::syncroChangeRound) {
         return;
@@ -459,22 +483,18 @@ void PoolSynchronizer::updateSynchroLog() {
     if (cs::Conveyer::instance().currentRoundNumber() < Consensus::syncroChangeRound) {
         return;
     }
-    //csdebug() << __func__ << ":";
     auto timeNow = cs::Utils::currentTimestamp();
     auto it = synchroLog_.begin();
     while (it != synchroLog_.end()) {
         auto msg = std::get<1>(it->second);
         auto timeEvent = std::get<2>(it->second);
-        //csdebug() << cs::Utils::byteStreamToHex(it->first) << ": " << std::get<0>(it->second).back() << ", time: " << timeEvent << ", status: " << static_cast<int>(msg);
         if ((msg != SyncroMessage::AwaitAnswer && timeNow > timeEvent + 50000) || ((std::get<1>(it->second) == SyncroMessage::NoAnswer && timeNow > timeEvent + 2000))) {
-            //csdebug() << __func__ << " -> " << synchroLog_.size() << ": key " << cs::Utils::byteStreamToHex(it->first) << " erased";
             it = synchroLog_.erase(it);
         }
         else {
             ++it;
         }
     }
-    //csdebug() << __func__ << ": finished";
 }
 
 bool PoolSynchronizer::removeSynchroLog(const cs::PublicKey& sender) {

--- a/csnode/src/transactionsindex.cpp
+++ b/csnode/src/transactionsindex.cpp
@@ -120,7 +120,14 @@ void TransactionsIndex::invalidate() {
 
 void TransactionsIndex::close() {
     if (db_->isOpen()) {
+      db_->flush();
       db_->close();
+    }
+}
+
+void TransactionsIndex::flush() {
+    if (db_->isOpen()) {
+      db_->flush();
     }
 }
 

--- a/lib/include/lib/system/service/unix_service.hpp
+++ b/lib/include/lib/system/service/unix_service.hpp
@@ -164,19 +164,24 @@ inline void Service::waitForSignals() {
 }
 
 inline void Service::doWork() {
+    // mux_ released before onInit so signals dispatch during slow-start
     {
         lock_type lock(mux_);
         threadsStatus_.workerReady = true;
-        bool ok = owner_.onInit(serviceName_);
         cv_.notify_all();
+    }
 
+    bool ok = owner_.onInit(serviceName_);
+
+    {
+        lock_type lock(mux_);
         if (!ok) {
             threadsStatus_.error = true;
+            threadsStatus_.workerReady = true;
+            cv_.notify_all();
             return;
         }
-
         cv_.wait(lock, [this]() { return threadsStatus_.mainReady; });
-
         if (threadsStatus_.error) {
             return;
         }

--- a/net/include/net/transport.hpp
+++ b/net/include/net/transport.hpp
@@ -34,8 +34,8 @@ class Node;
 
 class Transport : public net::HostEventHandler {
 public:
-    inline static volatile std::sig_atomic_t gSignalStatus = 0;
-    static void stop() { Transport::gSignalStatus = 1; }
+    inline static volatile std::sig_atomic_t gSignalStatus = 0;   // legacy flag; new path is stop()
+    void stop();   // wakes run loops immediately via cv
 
     using AddressAndPort = std::pair<std::string, uint16_t>;
     using BanList = std::vector<AddressAndPort>;
@@ -119,6 +119,10 @@ private:
     std::condition_variable newPacketsReceived_;
     std::mutex inboxMux_;
     PacketsQueue inboxQueue_;
+
+    std::atomic<bool> stopped_{false};
+    std::mutex shutdownMux_;
+    std::condition_variable shutdownCv_;
 
     Neighbourhood neighbourhood_;
     std::thread processorThread_;

--- a/net/src/transport.cpp
+++ b/net/src/transport.cpp
@@ -132,16 +132,34 @@ Transport::~Transport() {
 void Transport::run() {
     host_.Run();
     processorThread_ = std::thread(&Transport::processorRoutine, this);
-    std::this_thread::sleep_for(Neighbourhood::kPingInterval);
 
-    while (Transport::gSignalStatus == 0) {
+    {
+        std::unique_lock<std::mutex> lock(shutdownMux_);
+        shutdownCv_.wait_for(lock, Neighbourhood::kPingInterval,
+                             [this] { return stopped_.load(std::memory_order_acquire); });
+    }
+
+    while (!stopped_.load(std::memory_order_acquire) && Transport::gSignalStatus == 0) {
         pollSignalFlag();
+        if (stopped_.load(std::memory_order_acquire) || Transport::gSignalStatus != 0) break;
 
         neighbourhood_.pingNeighbours();
-
         emit mainThreadIterated();
-        std::this_thread::sleep_for(Neighbourhood::kPingInterval);
+
+        std::unique_lock<std::mutex> lock(shutdownMux_);
+        shutdownCv_.wait_for(lock, Neighbourhood::kPingInterval,
+                             [this] { return stopped_.load(std::memory_order_acquire); });
     }
+}
+
+void Transport::stop() {
+    stopped_.store(true, std::memory_order_release);
+    Transport::gSignalStatus = 1;
+    {
+        std::lock_guard<std::mutex> lock(shutdownMux_);
+    }
+    shutdownCv_.notify_all();
+    newPacketsReceived_.notify_all();
 }
 
 void Transport::OnMessageReceived(const net::NodeId& id, net::ByteVector&& data) {
@@ -234,13 +252,14 @@ void Transport::clearInbox() {
 void Transport::processorRoutine() {
     constexpr size_t kRoutineWaitTimeMs = 50;
 
-    while (Transport::gSignalStatus == 0) {
+    while (!stopped_.load(std::memory_order_acquire) && Transport::gSignalStatus == 0) {
         process();
 
         std::unique_lock lock(inboxMux_);
         newPacketsReceived_.wait_for(lock, std::chrono::milliseconds{kRoutineWaitTimeMs}, [this]() {
-            return !inboxQueue_.empty();
+            return !inboxQueue_.empty() || stopped_.load(std::memory_order_acquire);
         });
+        if (stopped_.load(std::memory_order_acquire)) break;
 
         while (!inboxQueue_.empty()) {
             PacketsQueue::SenderAndPacket senderAndPack;

--- a/solver/src/smartcontracts.cpp
+++ b/solver/src/smartcontracts.cpp
@@ -1751,10 +1751,6 @@ void SmartContracts::on_next_block_impl(const csdb::Pool& block, bool reading_db
                             if (!reading_db) {
                                 csdebug() << kLogPrefix << to_base58(abs_addr) << " state is unchanged after " << ref_start;
                             }
-                            if (pnode->isStopRequested()) {
-                                *should_stop = true;
-                                return;
-                            }
                         }
                         remove_from_queue(ref_start, reading_db);
                     }


### PR DESCRIPTION
## Problem

  Service::doWork held mux_ across the multi-hour onInit() during slow start,
  so SIGINT was queued behind the init and couldn't reach the main thread's
  signal-dispatch wait. Even when stop_ was set, two read-loop subscribers
  (Node::validateBlock and SmartContracts::on_next_block_impl) were
  signalling user-cancel by setting *shouldStop = true, which is csdb's
  test_failed (data-corruption) contract. And Node::init unconditionally
  called cachesSerializationManager_.clear() when BlockChain::init returned
  false, wiping the in-flight QUICK START slot on the way out.

  ## Symptom

  - Ctrl+C during slow-start did nothing visible. The node kept loading
    the full DB to the end and only then stopped.
  - On Ubuntu 22.04 the node could not be shut down at all during slow
    start. Signal delivery is stricter on newer glibc/pthread; with the
    mutex held the SIGINT never reached the main thread and the only way
    out was SIGKILL.
  - The stopped run logged DataIntegrityError: client reported violation
    of logic in pool <X> for whatever pool was at the head of the read
    loop when the signal arrived. Pool number tracked the abort point,
    not a real bad block.
  - qs/0 was erased, so the next start fell back to the last 5M-aligned
    periodic checkpoint instead of resuming where the previous run was.
  - Long-running Transport / PoolSynchronizer wait loops did not break
    on stop and held the node alive after shutdown.

  ## Fix

  - BlockChain::stop_ atomic plus requestStop() setter; storage_.open
    progress callback returns UserCancelled cleanly on stop_.
  - unix_service::doWork releases mux_ before onInit() so SIGINT delivers
    to the main thread during slow start.
  - Node::validateBlock and SmartContracts::on_next_block_impl stop
    signalling user-cancel through *shouldStop.
  - Node::init branches on isStopRequested(): user-cancel calls
    cachesSerializationManager_.save(0) and blockChain_.flushIndexes(),
    preserving the interim QS; real failure keeps the existing clear()
    path.
  - Transport::stop / PoolSynchronizer::stop use stopped_ atomic and a
    condition variable wakeup so wait loops break immediately on stop.
  - TransactionsIndex::flush() added; close() flushes before closing so
    LMDB is durable at orderly shutdown.
  - peer.cpp calls node_->stop() before destroy(), guaranteeing stop
    ordering on non-signal exit paths.

  ## Verification

  - Windows and Linux builds clean.
  - Ctrl+C during slow start stops the node immediately on both
    Ubuntu 20.04 and Ubuntu 22.04 (previously required SIGKILL on 22.04),
    no DataIntegrityError logged, qs/0 populated with interim progress;
    next start resumes byte-precisely from the stop point.
  - Normal shutdown: Transport and PoolSynchronizer wait loops exit
    immediately, no hangs.

  ## Risk

  Low. The save(0) branch only runs when isStopRequested(), the same
  trigger as the previous unconditional clear(), so paths that weren't
  user-cancel keep the old behavior. shouldStop removal restores csdb's
  contract; the prior usage was always emitting a false data-integrity
  error. Stop atomics are read-only off the hot path.