### PR TITLE
solver: fold peer stage-2 Zero::hash markers into local mask

### DIFF
--- a/solver/src/solverinterface.cpp
+++ b/solver/src/solverinterface.cpp
@@ -280,6 +280,29 @@ void SolverCore::gotStageTwo(const cs::StageTwo& stage) {
     stageTwoStorage.push_back(stage);
     csdebug() << kLogPrefix_ << __func__ << ": <-- stage-2 [" << static_cast<int>(stage.sender) << "] = " << stageTwoStorage.size();
 
+    // Fold peer stage-2 receipts into local untrusted set: if a BFT quorum of
+    // peers report Zero::hash for sender j, j is consensus-LOST → mark locally
+    // so chooseTimeStamp / realTrustedMask align with the network view.
+    if (pcontext) {
+        const size_t cnt = pcontext->cnt_trusted();
+        if (cnt > 0 && cnt <= Consensus::MaxTrustedNodes) {
+            std::vector<uint8_t> votes(cnt, 0);
+            for (const auto& s2 : stageTwoStorage) {
+                if (s2.hashes.size() != cnt) continue;
+                for (size_t j = 0; j < cnt; ++j) {
+                    if (s2.hashes[j] == cs::Zero::hash) ++votes[j];
+                }
+            }
+            const uint8_t quorum = static_cast<uint8_t>(cnt - cnt / 2);
+            const uint8_t self = pcontext->own_conf_number();
+            for (uint8_t j = 0; j < cnt; ++j) {
+                if (votes[j] >= quorum && j != self) {
+                    pcontext->mark_untrusted(j);
+                }
+            }
+        }
+    }
+
     if (!pstate) {
         return;
     }


### PR DESCRIPTION
# Stage-2 mask alignment via peer Zero::hash fold

  ## Problem
  `SolverCore::gotStageTwo` is pass-through; it never inspects the peer's `StageTwo::hashes[]` array. A peer that timed out stage-1 from sender `j` ships
  `hashes[j] == Zero::hash` on the wire as the explicit "I did not receive stage-1 from j" marker, but vanilla discards that signal.
  `TrustedStage3State::trusted_election` builds `realTrustedMask` from local `markUntrusted` only, and `chooseTimeStamp` iterates `stageOneStorage`
  skipping empty `roundTimeStamp` entries silently. A well-connected node with all 9 reals in storage and a timed-out peer with 5 reals + 4 empty-ts fakes
   use the same on-wire mask (0x1ff) but different storage contents, producing different `kFieldTimestamp` and different `deferredBlock_.hash()`.

  ## Symptom
  `Stage3 from T[X] ... final check NOT PASSED` for 3 to 6 of 9 trusted per round when the well-connected node is elected trusted. `Trusted-3: not enough
  active confidants, Bootstrap required` cascade. Mainnet block 175,936,847 finalized with 4 of 9 confidants showing zero reward, indicating
  `realTrustedMask` reduced from 0x1ff to a 5-bit mask through bootstrap reconciliation.

  ## Fix
  In `gotStageTwo`, count `Zero::hash` markers per position across all received stage-2s in `stageTwoStorage`. When a BFT quorum (`cnt - cnt/2`) of peers
  report position `j` as missing stage-1, call `pcontext->mark_untrusted(j)` locally. `trusted_election` then sets `realTrustedMask[j] =
  InvalidConfidantIndex` on this node, and `chooseTimeStamp` skips `j`, aligning the local view with the network majority before stage-3 signs.

  ## Verification
  Wire format and block format unchanged. Normal-round (no-timeout) code path is byte-identical to vanilla. Live observation pending on the affected VPS.

  ## Risk
  Low. Quorum threshold `cnt - cnt/2` = BFT majority; byzantine peers below the F threshold cannot trigger false over-marking. Math wall is untouched:
  scenarios with at least 4 truly lost senders still require bootstrap. No protocol version bump, no wire-format change; old and new nodes interoperate.
  In normal rounds the fold votes never cross quorum and the fix is a no-op.