### PR TITLE
 csnode: crash-safe checkpoints, LMDB-resident trxIndex watermark, Tr…

### DIFF
--- a/client/config/config.cpp
+++ b/client/config/config.cpp
@@ -35,6 +35,7 @@ const std::string BLOCK_NAME_HOST_INPUT = "host_input";
 const std::string BLOCK_NAME_HOST_OUTPUT = "host_output";
 const std::string BLOCK_NAME_HOST_ADDRESS = "host_address";
 const std::string BLOCK_NAME_POOL_SYNC = "pool_sync";
+const std::string BLOCK_NAME_STORAGE = "storage";
 const std::string BLOCK_NAME_API = "api";
 const std::string BLOCK_NAME_CONVEYER = "conveyer";
 const std::string BLOCK_NAME_EVENT_REPORTER = "event_report";
@@ -68,6 +69,10 @@ const std::string PARAM_NAME_PORT = "port";
 
 const std::string PARAM_NAME_POOL_SYNC_POOLS_COUNT = "block_pools_count";
 const std::string PARAM_NAME_POOL_SYNC_SEQ_VERIF_FREQ = "sequences_verification_frequency";
+
+const std::string PARAM_NAME_STORAGE_CHECKPOINT_KEEP = "checkpoint_keep";
+const std::string PARAM_NAME_STORAGE_CHECKPOINT_EVERY = "checkpoint_every";
+const std::string PARAM_NAME_STORAGE_CHECKPOINT_EVERY_MINUTES = "checkpoint_every_minutes";
 
 const std::string PARAM_NAME_API_PORT = "port";
 const std::string PARAM_NAME_AJAX_PORT = "ajax_port";
@@ -874,6 +879,7 @@ Config Config::readFromFile(const std::string& fileName) {
 
         result.setLoggerSettings(config);
         result.readPoolSynchronizerData(config);
+        result.readStorageData(config);
         result.readApiData(config);
         result.readConveyerData(config);
         result.readEventsReportData(config);
@@ -939,6 +945,23 @@ void Config::readPoolSynchronizerData(const boost::property_tree::ptree& config)
 
     checkAndSaveValue(data, block, PARAM_NAME_POOL_SYNC_POOLS_COUNT, poolSyncData_.blockPoolsCount);
     checkAndSaveValue(data, block, PARAM_NAME_POOL_SYNC_SEQ_VERIF_FREQ, poolSyncData_.sequencesVerificationFrequency);
+}
+
+void Config::readStorageData(const boost::property_tree::ptree& config) {
+    const std::string& block = BLOCK_NAME_STORAGE;
+
+    if (!config.count(block)) {
+        return;   // keep defaults
+    }
+
+    const boost::property_tree::ptree& data = config.get_child(block);
+    checkAndSaveValue(data, block, PARAM_NAME_STORAGE_CHECKPOINT_KEEP, storageData_.checkpointKeep);
+    checkAndSaveValue(data, block, PARAM_NAME_STORAGE_CHECKPOINT_EVERY, storageData_.checkpointEvery);
+    if (storageData_.checkpointEvery > 0 && storageData_.checkpointEvery < 1000) {
+        cswarning() << "config: checkpoint_every=" << storageData_.checkpointEvery << " is too low, clamping to 1000";
+        storageData_.checkpointEvery = 1000;
+    }
+    checkAndSaveValue(data, block, PARAM_NAME_STORAGE_CHECKPOINT_EVERY_MINUTES, storageData_.checkpointEveryMinutes);
 }
 
 void Config::readApiData(const boost::property_tree::ptree& config) {

--- a/client/config/config.hpp
+++ b/client/config/config.hpp
@@ -58,6 +58,12 @@ struct PoolSyncData {
     uint16_t sequencesVerificationFrequency = 350;   // sequences received verification frequency : 0-never; 1-once per round: other- in ms;
 };
 
+struct StorageData {
+    size_t checkpointKeep = 5;              // retained periodic checkpoints (qs/0 always kept on top)
+    size_t checkpointEvery = 500'000;       // blocks between periodic checkpoints (rolling history depth = checkpointEvery * checkpointKeep)
+    size_t checkpointEveryMinutes = 0;      // wall-clock fallback: also save if this many minutes elapsed since last save (0 = disabled; opt-in for slow networks)
+};
+
 struct ApiData {
     // on by default:
     uint16_t port = 9090;
@@ -214,6 +220,10 @@ public:
         return poolSyncData_;
     }
 
+    const StorageData& getStorageSettings() const {
+        return storageData_;
+    }
+
     const ApiData& getApiSettings() const {
         return apiData_;
     }
@@ -343,6 +353,7 @@ private:
 
     void setLoggerSettings(const boost::property_tree::ptree& config);
     void readPoolSynchronizerData(const boost::property_tree::ptree& config);
+    void readStorageData(const boost::property_tree::ptree& config);
     void readApiData(const boost::property_tree::ptree& config);
     void readConveyerData(const boost::property_tree::ptree& config);
     void readEventsReportData(const boost::property_tree::ptree& config);
@@ -390,6 +401,7 @@ private:
     boost::log::settings loggerSettings_{};
 
     PoolSyncData poolSyncData_;
+    StorageData storageData_;
     ApiData apiData_;
     DbSQLData dbSQLData_;
 

--- a/csnode/include/csnode/blockchain.hpp
+++ b/csnode/include/csnode/blockchain.hpp
@@ -1,6 +1,7 @@
 #ifndef BLOCKCHAIN_HPP
 #define BLOCKCHAIN_HPP
 
+#include <chrono>
 #include <list>
 #include <map>
 #include <memory>
@@ -86,6 +87,9 @@ public:
     bool isGood() const;
 
     void flushIndexes();
+
+    // false while trxIndex has an unwalked floor gap; consensus uses this to gate Trusted.
+    bool isTrxIndexReady() const;
 
     // return unique id of database if at least one unique block has written, otherwise (only genesis block) 0
     uint64_t uuid() const;
@@ -547,7 +551,8 @@ private:
 
     friend class cs::BlockChain_Serializer;
 
-    const size_t kQuickStartSaveCachesInterval = 10'000'000;
+    static constexpr size_t kQuickStartSaveCachesInterval = 500'000;
+    std::chrono::steady_clock::time_point lastCheckpointWallClock_ = std::chrono::steady_clock::now();
     int32_t blockRewardIntegral_;
     uint64_t blockRewardFraction_ ;
     int32_t miningCoefficientIntegral_;

--- a/csnode/include/csnode/caches_serialization_manager.hpp
+++ b/csnode/include/csnode/caches_serialization_manager.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <optional>
 #include <set>
 
 #include <client/params.hpp>
@@ -22,6 +24,14 @@ class WalletsCache;
 class WalletsIds;
 class RoundStat;
 
+// Binds a checkpoint to a specific chain-DB state. head.bin stores this; on
+// load the caller compares against the live chain DB before trusting caches.
+struct CheckpointHead {
+    cs::Sequence sequence{0};
+    cs::Bytes head_hash;
+    cs::Bytes prev_hash;
+};
+
 class CachesSerializationManager {
 public:
     CachesSerializationManager();
@@ -37,8 +47,23 @@ public:
 
     void clear(size_t version = 0);
 
-    bool save(size_t version = 0);
+    bool save(size_t version, const CheckpointHead& head);
+    bool save(size_t version = 0);   // legacy: no chain-binding (qs/0 from pre-A nodes)
+    // Optional verifier is called after each candidate's hashes pass; if it
+    // returns false (e.g. chain-binding mismatch), the candidate is
+    // quarantined and the next-older version is tried.
+    using ChainVerifier = std::function<bool(const CheckpointHead&)>;
+    bool load(const ChainVerifier& verify);
     bool load();
+    // The head info that load() recovered, if present. nullopt if the loaded
+    // checkpoint is pre-A (no head.bin) — caller skips chain-binding check.
+    std::optional<CheckpointHead> getLoadedHead() const;
+    // Sticky bit indicating the caches have been validated by a full
+    // genesis-to-head walk at some point. Cleared on a fresh init, set by
+    // BlockChain after Storage::open returns from a successful slow walk.
+    void setCompletedFromGenesis();
+    bool isLoadedFromCompletedSnapshot() const;
+    void pruneCheckpoints(size_t keep);
 
 private:
     struct Impl;

--- a/csnode/include/csnode/poolcache.hpp
+++ b/csnode/include/csnode/poolcache.hpp
@@ -72,6 +72,7 @@ private slots:
 private:
     void initialization();
     cs::PoolStoreType cachedType(cs::Sequence sequence) const;
+    void checkInvariant() const;
 
     std::vector<Interval> createInterval(cs::Sequence min, cs::Sequence max) const;
 

--- a/csnode/include/csnode/transactionsindex.hpp
+++ b/csnode/include/csnode/transactionsindex.hpp
@@ -7,7 +7,6 @@
 
 #include <csdb/address.hpp>
 #include <lib/system/common.hpp>
-#include <lib/system/mmappedfile.hpp>
 #include <lmdb.hpp>
 
 class BlockChain;
@@ -28,7 +27,21 @@ public:
     void close();
     void flush();
 
+    void pinFloor(Sequence floor);
+
+    // Delete trxIndex entries with curr_seq > floor; rewrite prev_seq>floor at curr==floor to kWrongSequence.
+    void trimToFloor(Sequence floor);
+
     bool recreate() const;
+
+    // false while pinFloor lifted past unwalked blocks; cleared by a slow-start walk.
+    bool isReady() const;
+
+    // true when lastIndexedPool_ claims a populated index but the LMDB is effectively empty.
+    bool looksEmpty() const;
+
+    // wipe lastIndexedPool_ and arm recreate_ so the next slow-start fully repopulates.
+    void forceRebuild();
 
     Sequence getPrevTransBlock(const csdb::Address& _addr, Sequence _curr) const;
 
@@ -48,17 +61,25 @@ private:
     void updateFromNextBlock(const csdb::Pool&);
     void updateLastIndexed();
 
-    static bool hasToRecreate(const std::string&, cs::Sequence&);
+    // Reads last_indexed value from the index LMDB. Returns true if a valid
+    // value was loaded into lastIndexedPool_, false if missing or sentinel.
+    bool loadLastIndexedFromDb();
 
     void setPrevTransBlock(const PublicKey&, cs::Sequence _curr, cs::Sequence _prev);
     void removeLastTransBlock(const PublicKey&, cs::Sequence _curr);
+
+    void loadIncompleteFromDb();
+    void updateIncompleteFlag();
+    void loadCompleteFlagFromDb();
+    void updateCompleteFlag();
 
     BlockChain& bc_;
     const std::string rootPath_;
     std::unique_ptr<Lmdb> db_;
     Sequence lastIndexedPool_ = 0;
-    bool recreate_;
-    MMappedFileWrap<FileSink> lastIndexedFile_;
+    bool recreate_ = false;
+    bool indexIncomplete_ = false;
+    bool indexComplete_ = false;
 
     std::map<csdb::Address, cs::Sequence> lapoos_;
 };

--- a/csnode/include/csnode/walletsids.hpp
+++ b/csnode/include/csnode/walletsids.hpp
@@ -54,6 +54,8 @@ public:
         return *norm_;
     }
 
+    WalletId getNextId() const { return nextId_; }
+
 private:
     struct Wallet {
         WalletAddress address; struct byAddress {};

--- a/csnode/src/apihandler_serializer.cpp
+++ b/csnode/src/apihandler_serializer.cpp
@@ -61,6 +61,7 @@ void APIHandler_Serializer::load(const std::filesystem::path& rootDir) {
 }
 
 void APIHandler_Serializer::clear(const std::filesystem::path& rootDir) {
+    (void)rootDir;
     auto clearHelper = [this](auto& entity) {
       auto ref = lockedReference(entity);
       ref->clear();
@@ -72,8 +73,6 @@ void APIHandler_Serializer::clear(const std::filesystem::path& rootDir) {
     clearHelper(*deployedByCreator_);
 
     mExecuteCount_->clear();
-
-    save(rootDir);
 }
 
 ::cscrypto::Hash APIHandler_Serializer::hash() {

--- a/csnode/src/blockchain.cpp
+++ b/csnode/src/blockchain.cpp
@@ -1,4 +1,5 @@
 #include <base58.h>
+#include <chrono>
 #include <csdb/currency.hpp>
 #include <lib/system/hash.hpp>
 #include <lib/system/logger.hpp>
@@ -115,12 +116,18 @@ bool BlockChain::init(
     bool successfulQuickStart = false;
 
     if (newBlockchainTop == cs::kWrongSequence) {
-        if (trxIndex_->recreate()) {
-            cslog() << "Cannot use QUICK START, trxIndex has to be recreated";
+        if (trxIndex_->recreate() || !trxIndex_->isReady() || trxIndex_->looksEmpty()) {
+            cswarning() << "trxIndex needs rebuild — skipping QuickStart, slow-start will populate it";
+            if (!trxIndex_->recreate()) {
+                trxIndex_->forceRebuild();
+            }
             bindSerializationManToCaches(serializationManPtr, initialConfidants);
         }
         else {
             successfulQuickStart = tryQuickStart(serializationManPtr, initialConfidants);
+            if (!successfulQuickStart && trxIndex_->recreate()) {
+                cslog() << "Cannot use QUICK START, trxIndex has to be recreated";
+            }
         }
     }
 
@@ -128,6 +135,7 @@ bool BlockChain::init(
     if (successfulQuickStart) {
         if (lastSequence_ != 0) {
             firstBlockToReadInDatabase = lastSequence_ + 1;
+            trxIndex_->pinFloor(lastSequence_.load());
             emit successfullQuickStartEvent(csdb::Amount(blockRewardIntegral_, blockRewardFraction_), csdb::Amount(miningCoefficientIntegral_, miningCoefficientFraction_), miningOn_, miningOn_, TimeMinStage1_);
         }
 
@@ -171,6 +179,7 @@ bool BlockChain::init(
     }
 
     if (newBlockchainTop != cs::kWrongSequence) {
+        if (trxIndex_) trxIndex_->trimToFloor(newBlockchainTop);
         return true;
     }
 
@@ -193,6 +202,10 @@ bool BlockChain::init(
         }
     }
 
+    if (!successfulQuickStart && !stop_ && serializationManPtr_) {
+        serializationManPtr_->setCompletedFromGenesis();
+    }
+
     good_ = true;
     blocksToBeRemoved_ = totalLoaded - 1; // any amount to remave after start
     return true;
@@ -206,6 +219,10 @@ void BlockChain::flushIndexes() {
     if (trxIndex_) {
         trxIndex_->flush();
     }
+}
+
+bool BlockChain::isTrxIndexReady() const {
+    return !trxIndex_ || trxIndex_->isReady();
 }
 
 uint64_t BlockChain::uuid() const {
@@ -246,6 +263,30 @@ void BlockChain::onReadFromDB(csdb::Pool block, bool* shouldStop) {
             }
             updateNonEmptyBlocks(block);
             walletsCacheUpdater_->loadNextBlock(block, block.confidants(), *this);
+        }
+    }
+
+    if (serializationManPtr_ && blockSeq && !*shouldStop) {
+        const auto& sto = cs::ConfigHolder::instance().config()->getStorageSettings();
+        const auto every = sto.checkpointEvery > 0 ? sto.checkpointEvery : kQuickStartSaveCachesInterval;
+        const auto now = std::chrono::steady_clock::now();
+        const bool byCount = (every > 0 && blockSeq % every == 0);
+        const bool byTime = (sto.checkpointEveryMinutes > 0
+            && now - lastCheckpointWallClock_ >= std::chrono::minutes(sto.checkpointEveryMinutes));
+        if (byCount || byTime) {
+            cslog() << kLogPrefix << "slow start: saving checkpoint at block " << WithDelimiters(blockSeq);
+            trxIndex_->flush();
+            cs::CheckpointHead head;
+            head.sequence = blockSeq;
+            head.head_hash = block.hash().to_binary();
+            head.prev_hash = block.previous_hash().to_binary();
+            if (serializationManPtr_->save(blockSeq, head)) {
+                serializationManPtr_->pruneCheckpoints(sto.checkpointKeep);
+                lastCheckpointWallClock_ = now;
+            }
+            else {
+                cserror() << kLogPrefix << "slow start: cannot save checkpoint at " << blockSeq;
+            }
         }
     }
 }
@@ -795,11 +836,27 @@ bool BlockChain::applyBlockToCaches(const csdb::Pool& pool) {
         return false;
     }
 
-    if (serializationManPtr_
-        && pool.sequence()
-        && pool.sequence() % kQuickStartSaveCachesInterval == 0
-        && !serializationManPtr_->save(pool.sequence())) {
-        cserror() << "Cannot save caches with version " << pool.sequence();
+    if (serializationManPtr_ && pool.sequence()) {
+        const auto& sto = cs::ConfigHolder::instance().config()->getStorageSettings();
+        const auto every = sto.checkpointEvery > 0 ? sto.checkpointEvery : kQuickStartSaveCachesInterval;
+        const auto now = std::chrono::steady_clock::now();
+        const bool byCount = (every > 0 && pool.sequence() % every == 0);
+        const bool byTime = (sto.checkpointEveryMinutes > 0
+            && now - lastCheckpointWallClock_ >= std::chrono::minutes(sto.checkpointEveryMinutes));
+        if (byCount || byTime) {
+            trxIndex_->flush();
+            cs::CheckpointHead head;
+            head.sequence = pool.sequence();
+            head.head_hash = pool.hash().to_binary();
+            head.prev_hash = pool.previous_hash().to_binary();
+            if (serializationManPtr_->save(pool.sequence(), head)) {
+                serializationManPtr_->pruneCheckpoints(sto.checkpointKeep);
+                lastCheckpointWallClock_ = now;
+            }
+            else {
+                cserror() << "Cannot save caches with version " << pool.sequence();
+            }
+        }
     }
 
     return true;
@@ -1048,6 +1105,21 @@ void BlockChain::tryFlushDeferredBlock() {
 void BlockChain::close() {
     stop_ = true;
     tryFlushDeferredBlock();
+
+    cs::CheckpointHead headInfo;
+    if (serializationManPtr_) {
+        const auto topSeq = getLastSeq();
+        auto headHash = getHashBySequence(topSeq);
+        if (!headHash.is_empty()) {
+            headInfo.sequence = topSeq;
+            headInfo.head_hash = headHash.to_binary();
+            if (topSeq > 0) {
+                auto prevHash = getHashBySequence(topSeq - 1);
+                if (!prevHash.is_empty()) headInfo.prev_hash = prevHash.to_binary();
+            }
+        }
+    }
+
     cs::Lock lock(dbLock_);
     storage_.close();
     cs::Connector::disconnect(&storage_.readBlockEvent(), this, &BlockChain::onReadFromDB);
@@ -1061,7 +1133,7 @@ void BlockChain::close() {
 
     csinfo() << "Blockchain: try to save caches for QUICK START.";
 
-    if (serializationManPtr_->save()) {
+    if (serializationManPtr_->save(0, headInfo)) {
       csinfo() << "Blockchain: caches for QUICK START saved successfully.";
     }
     else {

--- a/csnode/src/blockchain_serializer.cpp
+++ b/csnode/src/blockchain_serializer.cpp
@@ -10,6 +10,7 @@
 #include <csnode/blockchain.hpp>
 #include <csnode/blockchain_serializer.hpp>
 #include <csnode/serializers_helper.hpp>
+#include <lib/system/logger.hpp>
 
 namespace {
 const std::string kDataFileName = "blockchain.dat";
@@ -35,6 +36,8 @@ void BlockChain_Serializer::bind(BlockChain& bchain, std::set<cs::PublicKey>& in
 }
 
 void BlockChain_Serializer::clear(const std::filesystem::path& rootDir) {
+    cslog() << "TRACE: BlockChain_Serializer::clear called for " << rootDir
+            << "; resetting in-memory lastSequence_ from " << lastSequence_->load() << " to 0";
     previousNonEmpty_->clear();
     lastNonEmptyBlock_->poolSeq = 0;
     lastNonEmptyBlock_->transCount = 0;
@@ -49,7 +52,6 @@ void BlockChain_Serializer::clear(const std::filesystem::path& rootDir) {
     *stakingOn_ = false;
     *miningOn_ = false;
     *TimeMinStage1_ = 500;
-    save(rootDir);
 }
 
 void BlockChain_Serializer::save(const std::filesystem::path& rootDir) {
@@ -90,6 +92,9 @@ void BlockChain_Serializer::load(const std::filesystem::path& rootDir) {
 
     Sequence lastSequence;
     ia >> lastSequence;
+    cslog() << "TRACE: BlockChain_Serializer::load called for " << rootDir
+            << "; setting in-memory lastSequence_ from " << lastSequence_->load()
+            << " to " << lastSequence;
     lastSequence_->store(lastSequence);
     ia >> *initialConfidants_;
 

--- a/csnode/src/blockvalidatorplugins.cpp
+++ b/csnode/src/blockvalidatorplugins.cpp
@@ -152,11 +152,8 @@ ValidationPlugin::ErrorType HashValidator::validateBlock(const csdb::Pool& block
 
   auto prevHash = block.previous_hash();
   auto& prevBlock = getPrevBlock();
-  
-  auto data = prevBlock.to_binary();
-  auto countedPrevHash = csdb::PoolHash::calc_from_data(cs::Bytes(data.data(),
-                                                          data.data() +
-                                                          prevBlock.hashingLength()));
+
+  auto countedPrevHash = prevBlock.hash();
   if (prevHash != countedPrevHash) {
       cserror() << kLogPrefix << ": hash " << countedPrevHash.to_string() << " of block (" << prevBlock.sequence()
           << ") hash != real prev pool's hash " << prevHash.to_string() << " of (" << block.sequence() << ")";
@@ -387,10 +384,7 @@ ValidationPlugin::ErrorType BalanceOnlyChecker::validateBlock(const csdb::Pool& 
     csdebug() << kLogPrefix << ": checking Block";
     auto prevHash = pool.previous_hash();
     auto prevBlock = getBlockChain().getLastBlock();
-    auto data = prevBlock.to_binary();
-    auto countedPrevHash = csdb::PoolHash::calc_from_data(cs::Bytes(data.data(),
-        data.data() +
-        prevBlock.hashingLength()));
+    auto countedPrevHash = prevBlock.hash();
     if (prevHash != countedPrevHash) {
         csfatal() << kLogPrefix << ": hash of block (" << prevBlock.sequence()
             << ") hash: " << countedPrevHash.to_string() << " != real prev pool's hash of (" << pool.sequence() << "): " << prevHash.to_string();

--- a/csnode/src/caches_serialization_manager.cpp
+++ b/csnode/src/caches_serialization_manager.cpp
@@ -4,7 +4,17 @@
 #include <exception>
 #include <filesystem>
 #include <fstream>
+#include <optional>
+#include <sstream>
 #include <vector>
+
+#ifdef _WIN32
+#  include <io.h>
+#  include <fcntl.h>
+#else
+#  include <fcntl.h>
+#  include <unistd.h>
+#endif
 
 #include <csnode/blockchain_serializer.hpp>
 #include <csnode/smartcontracts_serializer.hpp>
@@ -16,6 +26,46 @@
 #include <csconnector/csconnector.hpp>
 
 #include <lib/system/logger.hpp>
+
+namespace {
+
+void fsyncFile(const std::filesystem::path& p) {
+#ifdef _WIN32
+    int fd = ::_wopen(p.wstring().c_str(), _O_RDONLY | _O_BINARY);
+    if (fd >= 0) {
+        ::_commit(fd);
+        ::_close(fd);
+    }
+#else
+    int fd = ::open(p.c_str(), O_RDONLY);
+    if (fd >= 0) {
+        ::fsync(fd);
+        ::close(fd);
+    }
+#endif
+}
+
+void fsyncDir([[maybe_unused]] const std::filesystem::path& dir) {
+#ifndef _WIN32
+    int fd = ::open(dir.c_str(), O_RDONLY | O_DIRECTORY);
+    if (fd >= 0) {
+        ::fsync(fd);
+        ::close(fd);
+    }
+#endif
+}
+
+void fsyncDirContents(const std::filesystem::path& dir) {
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(dir, ec)) {
+        if (ec) break;
+        if (entry.is_regular_file(ec)) {
+            fsyncFile(entry.path());
+        }
+    }
+}
+
+} // namespace
 
 namespace cs {
 
@@ -33,7 +83,17 @@ struct CachesSerializationManager::Impl {
 
     const std::string kHashesFile = "quick_start_hashes.dat";
     const std::string kQuickStartRoot = "qs";
+    const std::string kHeadFile = "head.bin";
+    const std::string kSchemaFile = "schema_version";
+    const std::string kSentinelFile = "sentinel.bin";
+    static constexpr uint8_t kCurrentSchemaVersion = 1;
+    static constexpr uint32_t kHeadMagic = 0x44414548u; // "HEAD" LE
+    static constexpr uint8_t kSentinelCompletedFromGenesisBit = 1 << 0;
     const std::vector <std::string> hashesDivisions = {"blockchain", "smartcontracts","walletscache","walletsIds","roundstat","tokensmaster","apihandler"};
+
+    std::optional<CheckpointHead> loadedHead_{};
+    bool completedFromGenesis_ = false;
+    bool loadedFromCompleted_ = false;
 
     enum BindBits {
       BlockChainBit,
@@ -63,25 +123,54 @@ struct CachesSerializationManager::Impl {
         );
     }
 
-    void clear(size_t version) {
-        csinfo() << "CachesSerializationManager: try to clear version " << version;
-        std::filesystem::path p(kQuickStartRoot);
-        p /= std::to_string(version);
-
+    void clearInMem() {
+        std::filesystem::path unused;
         try {
-            blockchainSerializer.clear(p);
-            smartContractsSerializer.clear(p);
+            blockchainSerializer.clear(unused);
+            smartContractsSerializer.clear(unused);
 #ifdef NODE_API
-            tokensMasterSerializer.clear(p);
-            apiHandlerSerializer.clear(p);
+            tokensMasterSerializer.clear(unused);
+            apiHandlerSerializer.clear(unused);
 #endif
-            walletsCacheSerializer.clear(p);
-            walletsIdsSerializer.clear(p);
-            roundStatSerializer.clear(p);
-            std::filesystem::remove_all(p);
+            walletsCacheSerializer.clear(unused);
+            walletsIdsSerializer.clear(unused);
+            roundStatSerializer.clear(unused);
         }
         catch (const std::exception& e) {
-            cswarning() << "CachesSerializationManager: error on clear: " << e.what();
+            cswarning() << "CachesSerializationManager: error on clearInMem: " << e.what();
+        }
+    }
+
+    void quarantineVersion(size_t version) {
+        std::filesystem::path p(kQuickStartRoot);
+        p /= std::to_string(version);
+        std::filesystem::path q(kQuickStartRoot);
+        q /= (std::to_string(version) + ".bad");
+        std::error_code ec;
+        std::filesystem::remove_all(q, ec);
+        std::filesystem::rename(p, q, ec);
+        if (ec) {
+            cswarning() << "CachesSerializationManager: quarantine rename "
+                        << p << " -> " << q << " failed: " << ec.message()
+                        << "; removing failed version dir";
+            std::filesystem::remove_all(p, ec);
+        }
+        else {
+            csinfo() << "CachesSerializationManager: quarantined failed version " << version
+                     << " to " << q;
+        }
+    }
+
+    void clear(size_t version) {
+        csinfo() << "CachesSerializationManager: try to clear version " << version;
+        clearInMem();
+        std::filesystem::path p(kQuickStartRoot);
+        p /= std::to_string(version);
+        std::error_code ec;
+        std::filesystem::remove_all(p, ec);
+        if (ec) {
+            cswarning() << "CachesSerializationManager: remove_all "
+                        << p << " failed: " << ec.message();
         }
     }
 
@@ -111,32 +200,114 @@ struct CachesSerializationManager::Impl {
       csdebug() << "Got apihandler hashes";
 #endif
 
-      return cscrypto::helpers::bin2Hex(
+      auto hex = cscrypto::helpers::bin2Hex(
         result.data(),
         result.size()
       );
+      while (!hex.empty() && hex.back() == '\0') hex.pop_back();   // strip libsodium's trailing null
+      return hex;
     }
 
-    void saveHashes(size_t version) {
-        std::ofstream f(
-          std::filesystem::path(kQuickStartRoot) /
-          std::to_string(version) /
-          kHashesFile
-        );
+    void saveHashes(const std::filesystem::path& dir) {
+        std::ofstream f(dir / kHashesFile);
         f << getHashes();
     }
 
-    std::vector<std::string> divideHashes(std::string initial) {
-        std::vector<std::string> res;
-        size_t hexHashLen = 64;
-        auto start = initial.begin();
-        int inc = 0;
+    void saveSchema(const std::filesystem::path& dir) {
+        std::ofstream f(dir / kSchemaFile, std::ios::binary);
+        const uint8_t v = kCurrentSchemaVersion;
+        f.write(reinterpret_cast<const char*>(&v), sizeof(v));
+    }
 
-        while (inc < 6) {
-            auto tmp = std::string(start, start + hexHashLen);
-            res.push_back(tmp);
-            start = start + hexHashLen;
-            ++inc;
+    // Returns the schema version, or 0 if no schema file (legacy checkpoint).
+    uint8_t loadSchema(const std::filesystem::path& dir) {
+        std::ifstream f(dir / kSchemaFile, std::ios::binary);
+        if (!f.is_open()) return 0;
+        uint8_t v = 0;
+        f.read(reinterpret_cast<char*>(&v), sizeof(v));
+        return f ? v : 0;
+    }
+
+    void saveHead(const std::filesystem::path& dir, const CheckpointHead& head) {
+        std::ofstream f(dir / kHeadFile, std::ios::binary);
+        const uint32_t magic = kHeadMagic;
+        f.write(reinterpret_cast<const char*>(&magic), sizeof(magic));
+        const uint64_t seq = static_cast<uint64_t>(head.sequence);
+        f.write(reinterpret_cast<const char*>(&seq), sizeof(seq));
+        const uint16_t hh = static_cast<uint16_t>(head.head_hash.size());
+        f.write(reinterpret_cast<const char*>(&hh), sizeof(hh));
+        if (hh) f.write(reinterpret_cast<const char*>(head.head_hash.data()), hh);
+        const uint16_t ph = static_cast<uint16_t>(head.prev_hash.size());
+        f.write(reinterpret_cast<const char*>(&ph), sizeof(ph));
+        if (ph) f.write(reinterpret_cast<const char*>(head.prev_hash.data()), ph);
+    }
+
+    void saveSentinel(const std::filesystem::path& dir) {
+        std::ofstream f(dir / kSentinelFile, std::ios::binary);
+        uint8_t flags = 0;
+        if (completedFromGenesis_) flags |= kSentinelCompletedFromGenesisBit;
+        f.write(reinterpret_cast<const char*>(&flags), sizeof(flags));
+    }
+
+    // returns false for missing/legacy files
+    bool loadSentinel(const std::filesystem::path& dir) {
+        std::ifstream f(dir / kSentinelFile, std::ios::binary);
+        if (!f.is_open()) return false;
+        uint8_t flags = 0;
+        f.read(reinterpret_cast<char*>(&flags), sizeof(flags));
+        if (!f) return false;
+        return (flags & kSentinelCompletedFromGenesisBit) != 0;
+    }
+
+    std::optional<CheckpointHead> loadHead(const std::filesystem::path& dir) {
+        std::ifstream f(dir / kHeadFile, std::ios::binary);
+        if (!f.is_open()) return std::nullopt;
+        uint32_t magic = 0;
+        f.read(reinterpret_cast<char*>(&magic), sizeof(magic));
+        if (!f || magic != kHeadMagic) {
+            cswarning() << "CachesSerializationManager: head.bin magic mismatch in " << dir;
+            return std::nullopt;
+        }
+        CheckpointHead head;
+        uint64_t seq = 0;
+        f.read(reinterpret_cast<char*>(&seq), sizeof(seq));
+        head.sequence = static_cast<cs::Sequence>(seq);
+        uint16_t hh = 0;
+        f.read(reinterpret_cast<char*>(&hh), sizeof(hh));
+        if (hh) {
+            head.head_hash.resize(hh);
+            f.read(reinterpret_cast<char*>(head.head_hash.data()), hh);
+        }
+        uint16_t ph = 0;
+        f.read(reinterpret_cast<char*>(&ph), sizeof(ph));
+        if (ph) {
+            head.prev_hash.resize(ph);
+            f.read(reinterpret_cast<char*>(head.prev_hash.data()), ph);
+        }
+        if (!f) {
+            cswarning() << "CachesSerializationManager: head.bin truncated in " << dir;
+            return std::nullopt;
+        }
+        return head;
+    }
+
+    std::vector<std::string> divideHashes(const std::string& initial) const {
+        std::vector<std::string> res;
+        constexpr size_t hexHashLen = 64;
+        if (initial.size() % hexHashLen != 0) {
+            cswarning() << "CachesSerializationManager: hash string length " << initial.size()
+                        << " is not a multiple of " << hexHashLen;
+            return res;
+        }
+        const size_t count = initial.size() / hexHashLen;
+        if (count > hashesDivisions.size()) {
+            cswarning() << "CachesSerializationManager: too many hashes (" << count
+                        << "), max expected " << hashesDivisions.size();
+            return res;
+        }
+        res.reserve(count);
+        for (size_t i = 0; i < count; ++i) {
+            res.emplace_back(initial, i * hexHashLen, hexHashLen);
         }
         return res;
     }
@@ -149,21 +320,35 @@ struct CachesSerializationManager::Impl {
           std::to_string(version) /
           kHashesFile
         );
-        
+
         std::string writtenHashes;
         f >> writtenHashes;
+        while (!writtenHashes.empty() && writtenHashes.back() == '\0') writtenHashes.pop_back();   // legacy files had trailing null
+        if (writtenHashes.empty()) {
+            cserror() << "CachesSerializationManager: hash file empty or missing for version " << version;
+            return false;
+        }
+        if (writtenHashes.size() != currentHashes.size()) {
+            cserror() << "CachesSerializationManager: hash file size mismatch (build/schema drift), written="
+                      << writtenHashes.size() << " current=" << currentHashes.size();
+            return false;
+        }
         auto writtenHashesDivided = divideHashes(writtenHashes);
         auto currentHashesDivided = divideHashes(currentHashes);
+        if (writtenHashesDivided.size() != currentHashesDivided.size()
+            || writtenHashesDivided.empty()) {
+            cserror() << "CachesSerializationManager: divided hash count mismatch";
+            return false;
+        }
         auto wIt = writtenHashesDivided.begin();
         auto cIt = currentHashesDivided.begin();
         auto nIt = hashesDivisions.begin();
-        while (wIt < writtenHashesDivided.end()) {
+        while (wIt != writtenHashesDivided.end() && nIt != hashesDivisions.end()) {
             if (*wIt != *cIt) {
                 csinfo() << *nIt << " current: "
                     << *cIt
                     << ", written: "
                     << *wIt;
-
             }
             ++wIt;
             ++cIt;
@@ -176,6 +361,10 @@ struct CachesSerializationManager::Impl {
         std::set<size_t> result;
 
         for (auto& p : std::filesystem::directory_iterator(kQuickStartRoot)) {
+            const auto ext = p.path().extension();
+            if (ext == ".tmp" || ext == ".bad" || ext == ".prev") {
+                continue;
+            }
             auto path = p.path().string();
             if (path.empty()) {
                 continue;
@@ -199,11 +388,22 @@ struct CachesSerializationManager::Impl {
         return result;
     }
 
-    bool loadVersion(size_t version) {
+    bool loadVersion(size_t version, const std::function<bool(const CheckpointHead&)>& verify) {
         csinfo() << "CachesSerializationManager: try to load version " << version;
         try {
             std::filesystem::path p(kQuickStartRoot);
             p /= std::to_string(version);
+
+            const uint8_t schema = loadSchema(p);
+            if (schema != 0 && schema != kCurrentSchemaVersion) {
+                cserror() << "CachesSerializationManager: schema_version mismatch for "
+                          << version << " (file=" << static_cast<int>(schema)
+                          << " current=" << static_cast<int>(kCurrentSchemaVersion)
+                          << "); quarantining";
+                clearInMem();
+                quarantineVersion(version);
+                return false;
+            }
 
             blockchainSerializer.load(p);
             csinfo() << "Blockchain settings: loaded";
@@ -222,18 +422,34 @@ struct CachesSerializationManager::Impl {
             csinfo() << "API handler: loaded";
 #endif
             if (!checkHashes(version)) {
-                cserror() << "CachesSerializationManager: invalid hashes on load";
-                clear(version);
+                cserror() << "CachesSerializationManager: invalid hashes on load, quarantining version " << version;
+                clearInMem();
+                quarantineVersion(version);
+                return false;
+            }
+            loadedHead_ = loadHead(p);   // nullopt for legacy (no head.bin)
+            loadedFromCompleted_ = loadSentinel(p);
+            // a completed snapshot remains completed after a successful reload
+            if (loadedFromCompleted_) completedFromGenesis_ = true;
+            if (verify && loadedHead_.has_value() && !verify(*loadedHead_)) {
+                cserror() << "CachesSerializationManager: chain-binding verification failed for version "
+                          << version << "; quarantining";
+                loadedHead_.reset();
+                loadedFromCompleted_ = false;
+                clearInMem();
+                quarantineVersion(version);
                 return false;
             }
         } catch (const std::exception& e) {
             cserror() << "CachesSerializationManager: error on load: "
-                      << e.what();
-            clear(version);
+                      << e.what() << "; quarantining version " << version;
+            clearInMem();
+            quarantineVersion(version);
             return false;
         } catch (...) {
-            cserror() << "CachesSerializationManager: unknown error on load";
-            clear(version);
+            cserror() << "CachesSerializationManager: unknown error on load; quarantining version " << version;
+            clearInMem();
+            quarantineVersion(version);
             return false;
         }
         return true;
@@ -245,6 +461,40 @@ CachesSerializationManager::CachesSerializationManager()
   if (!std::filesystem::exists(pImpl_->kQuickStartRoot)
       || !std::filesystem::is_directory(pImpl_->kQuickStartRoot)) {
     std::filesystem::create_directories(pImpl_->kQuickStartRoot);
+    return;
+  }
+  // Pass 1: clean .tmp; collect .prev for crash-mid-publish recovery
+  std::vector<std::filesystem::path> prevDirs;
+  for (auto& p : std::filesystem::directory_iterator(pImpl_->kQuickStartRoot)) {
+    const auto ext = p.path().extension();
+    if (ext == ".tmp") {
+      std::error_code ec;
+      std::filesystem::remove_all(p.path(), ec);
+    }
+    else if (ext == ".prev") {
+      prevDirs.push_back(p.path());
+    }
+    // .bad dirs are preserved across boots for forensic inspection
+  }
+  // Pass 2: recover .prev if final dir is missing; otherwise drop the backup.
+  for (const auto& prev : prevDirs) {
+    std::filesystem::path final_path = prev;
+    final_path.replace_extension();
+    std::error_code ec;
+    if (std::filesystem::exists(final_path, ec)) {
+      std::filesystem::remove_all(prev, ec);
+    }
+    else {
+      std::filesystem::rename(prev, final_path, ec);
+      if (ec) {
+        cswarning() << "CachesSerializationManager: recover " << prev
+                    << " -> " << final_path << " failed: " << ec.message();
+      }
+      else {
+        csinfo() << "CachesSerializationManager: recovered prior version from "
+                 << prev << " -> " << final_path;
+      }
+    }
   }
 }
 
@@ -290,59 +540,164 @@ void CachesSerializationManager::bind([[maybe_unused]] api::APIHandler& apih) {
 }
 
 bool CachesSerializationManager::save(size_t version) {
+    return save(version, CheckpointHead{});
+}
+
+bool CachesSerializationManager::save(size_t version, const CheckpointHead& head) {
     if (!pImpl_->bindingsReady()) {
         cserror() << "CachesSerializationManager: save error: "
                   << "bindings are not ready";
         return false;
     }
 
-    try {
-        std::filesystem::path p(pImpl_->kQuickStartRoot);
-        p /= std::to_string(version);
-        if (!std::filesystem::exists(p) || !std::filesystem::is_directory(p)) {
-          std::filesystem::create_directories(p);
-        }
+    const std::filesystem::path root(pImpl_->kQuickStartRoot);
+    const std::filesystem::path final_path = root / std::to_string(version);
+    const std::filesystem::path tmp_path   = root / (std::to_string(version) + ".tmp");
 
-        pImpl_->blockchainSerializer.save(p);
-        pImpl_->smartContractsSerializer.save(p);
-        pImpl_->walletsCacheSerializer.save(p);
-        pImpl_->walletsIdsSerializer.save(p);
-        pImpl_->roundStatSerializer.save(p);
+    std::error_code ec;
+    std::filesystem::remove_all(tmp_path, ec);
+    std::filesystem::create_directories(tmp_path, ec);
+    if (ec) {
+        cserror() << "CachesSerializationManager: cannot create " << tmp_path << ": " << ec.message();
+        return false;
+    }
+
+    try {
+        pImpl_->blockchainSerializer.save(tmp_path);
+        pImpl_->smartContractsSerializer.save(tmp_path);
+        pImpl_->walletsCacheSerializer.save(tmp_path);
+        pImpl_->walletsIdsSerializer.save(tmp_path);
+        pImpl_->roundStatSerializer.save(tmp_path);
 #ifdef NODE_API
-        pImpl_->tokensMasterSerializer.save(p);
-        pImpl_->apiHandlerSerializer.save(p);
+        pImpl_->tokensMasterSerializer.save(tmp_path);
+        pImpl_->apiHandlerSerializer.save(tmp_path);
 #endif
-        pImpl_->saveHashes(version);
+        pImpl_->saveHashes(tmp_path);
+        pImpl_->saveSchema(tmp_path);
+        pImpl_->saveSentinel(tmp_path);
+        if (!head.head_hash.empty()) {
+            pImpl_->saveHead(tmp_path, head);
+        }
     } catch (const std::exception& e) {
-        cserror() << "CachesSerializationManager: error on save: "
-                  << e.what();
+        cserror() << "CachesSerializationManager: error on save: " << e.what();
+        std::filesystem::remove_all(tmp_path, ec);
         return false;
     } catch (...) {
         cserror() << "CachesSerializationManager: unknown save error ";
+        std::filesystem::remove_all(tmp_path, ec);
         return false;
     }
+
+    // ensure data is on disk before we publish via rename
+    fsyncDirContents(tmp_path);
+
+    // .prev rename-over-replace: prior version preserved until new one is published
+    const std::filesystem::path backup_path = root / (std::to_string(version) + ".prev");
+    std::filesystem::remove_all(backup_path, ec);
+
+    const bool hadOldFinal = std::filesystem::exists(final_path, ec);
+    if (hadOldFinal) {
+        std::filesystem::rename(final_path, backup_path, ec);
+        if (ec) {
+            cserror() << "CachesSerializationManager: backup rename "
+                      << final_path << " -> " << backup_path << " failed: " << ec.message();
+            std::filesystem::remove_all(tmp_path, ec);
+            return false;
+        }
+    }
+
+    std::filesystem::rename(tmp_path, final_path, ec);
+    if (ec) {
+        cserror() << "CachesSerializationManager: publish rename "
+                  << tmp_path << " -> " << final_path << " failed: " << ec.message();
+        if (hadOldFinal) {
+            std::error_code restoreEc;
+            std::filesystem::rename(backup_path, final_path, restoreEc);
+            if (restoreEc) {
+                cswarning() << "CachesSerializationManager: could not restore prior version "
+                            << backup_path << " -> " << final_path << ": " << restoreEc.message();
+            }
+        }
+        std::filesystem::remove_all(tmp_path, ec);
+        return false;
+    }
+
+    // make rename itself durable (POSIX requires fsync of the parent dir)
+    fsyncDir(root);
+
+    // publish succeeded — drop the backup
+    std::filesystem::remove_all(backup_path, ec);
     return true;
 }
 
 bool CachesSerializationManager::load() {
+    return load(ChainVerifier{});
+}
+
+bool CachesSerializationManager::load(const ChainVerifier& verify) {
     if (!pImpl_->bindingsReady()) {
         cserror() << "CachesSerializationManager: load error: "
                   << "bindings are not ready";
         return false;
     }
 
-    // try to load most recent version first
-    if (pImpl_->loadVersion(0)) {
-        csinfo() << "CachesSerializationManager: successfully load version 0";
-        return true;
-    }
+    pImpl_->loadedHead_.reset();
+    pImpl_->loadedFromCompleted_ = false;
+
+    // Rank by max(head.seq, dir_name); mtime tiebreaker. Legacy accepted.
+    struct Candidate {
+        cs::Sequence headSeq = 0;
+        cs::Sequence effectiveSeq = 0;
+        std::filesystem::file_time_type mtime{};
+        size_t version = 0;
+        bool hasHead = false;
+    };
 
     auto versions = pImpl_->getVersions();
+    std::vector<Candidate> candidates;
+    candidates.reserve(versions.size());
+    for (size_t v : versions) {
+        std::filesystem::path p(pImpl_->kQuickStartRoot);
+        p /= std::to_string(v);
+        Candidate c;
+        c.version = v;
+        auto head = pImpl_->loadHead(p);
+        if (head) {
+            c.headSeq = head->sequence;
+            c.hasHead = true;
+        }
+        c.effectiveSeq = std::max<cs::Sequence>(c.headSeq, static_cast<cs::Sequence>(v));
+        std::error_code ec;
+        auto sentinelPath = p / pImpl_->kSentinelFile;
+        if (std::filesystem::exists(sentinelPath, ec)) {
+            c.mtime = std::filesystem::last_write_time(sentinelPath, ec);
+        } else {
+            c.mtime = std::filesystem::last_write_time(p, ec);
+        }
+        candidates.push_back(c);
+    }
 
-    // load versions starting from greatest numbers
-    for (auto it = versions.rbegin(); it != versions.rend(); ++it) {
-        if (pImpl_->loadVersion(*it)) {
-            csinfo() << "CachesSerializationManager: successfully load version " << *it;
+    std::sort(candidates.begin(), candidates.end(), [](const Candidate& a, const Candidate& b) {
+        if (a.effectiveSeq != b.effectiveSeq) return a.effectiveSeq > b.effectiveSeq;
+        return a.mtime > b.mtime;
+    });
+
+    if (candidates.empty()) {
+        cserror() << "CachesSerializationManager: no checkpoint candidates";
+        return false;
+    }
+
+    csinfo() << "CachesSerializationManager: checkpoint candidates (in order tried):";
+    for (const auto& c : candidates) {
+        csinfo() << "  qs/" << c.version
+                 << "  head.seq=" << (c.hasHead ? std::to_string(c.headSeq) : std::string("<legacy>"))
+                 << "  effective=" << c.effectiveSeq;
+    }
+
+    for (const auto& c : candidates) {
+        if (pImpl_->loadVersion(c.version, verify)) {
+            csinfo() << "CachesSerializationManager: successfully loaded qs/" << c.version
+                     << " (effective seq=" << c.effectiveSeq << ")";
             return true;
         }
     }
@@ -351,11 +706,66 @@ bool CachesSerializationManager::load() {
     return false;
 }
 
+std::optional<CheckpointHead> CachesSerializationManager::getLoadedHead() const {
+    return pImpl_->loadedHead_;
+}
+
+void CachesSerializationManager::setCompletedFromGenesis() {
+    pImpl_->completedFromGenesis_ = true;
+}
+
+bool CachesSerializationManager::isLoadedFromCompletedSnapshot() const {
+    return pImpl_->loadedFromCompleted_;
+}
+
 void CachesSerializationManager::clear(size_t version) {
     if (!pImpl_->bindingsReady()) {
         return;
     }
     pImpl_->clear(version);
+}
+
+void CachesSerializationManager::pruneCheckpoints(size_t keep) {
+    if (!pImpl_->bindingsReady()) {
+        return;
+    }
+    auto versions = pImpl_->getVersions();
+    versions.erase(0);
+    if (versions.size() <= keep) {
+        return;
+    }
+    // Prune by mtime so recent saves survive over high-number legacy.
+    struct V {
+        size_t version;
+        std::filesystem::file_time_type mtime;
+    };
+    std::vector<V> ordered;
+    ordered.reserve(versions.size());
+    for (size_t v : versions) {
+        std::filesystem::path p(pImpl_->kQuickStartRoot);
+        p /= std::to_string(v);
+        std::error_code ec;
+        auto sentinel = p / pImpl_->kSentinelFile;
+        auto mt = std::filesystem::exists(sentinel, ec)
+            ? std::filesystem::last_write_time(sentinel, ec)
+            : std::filesystem::last_write_time(p, ec);
+        ordered.push_back({v, mt});
+    }
+    // Newest mtime first; keep the first `keep`, prune the rest.
+    std::sort(ordered.begin(), ordered.end(),
+              [](const V& a, const V& b) { return a.mtime > b.mtime; });
+
+    for (size_t i = keep; i < ordered.size(); ++i) {
+        std::filesystem::path p(pImpl_->kQuickStartRoot);
+        p /= std::to_string(ordered[i].version);
+        std::error_code ec;
+        std::filesystem::remove_all(p, ec);
+        if (ec) {
+            cswarning() << "CachesSerializationManager: prune failed for " << p << ": " << ec.message();
+        } else {
+            csdebug() << "CachesSerializationManager: pruned old qs/" << ordered[i].version;
+        }
+    }
 }
 
 } // namespace cs

--- a/csnode/src/multiwallets.cpp
+++ b/csnode/src/multiwallets.cpp
@@ -21,14 +21,16 @@ csdb::Amount cs::MultiWallets::balance(const cs::PublicKey& key) const {
     cs::Lock lock(mutex_);
 
     auto& keys = indexes_.get<Tags::ByPublicKey>();
-    return keys.find(key)->balance_;
+    auto it = keys.find(key);
+    return it == keys.end() ? csdb::Amount(0) : it->balance_;
 }
 
 uint64_t cs::MultiWallets::transactionsCount(const cs::PublicKey& key) const {
     cs::Lock lock(mutex_);
 
     auto& keys = indexes_.get<Tags::ByPublicKey>();
-    return keys.find(key)->transNum_;
+    auto it = keys.find(key);
+    return it == keys.end() ? 0 : it->transNum_;
 }
 
 #ifdef MONITOR_NODE
@@ -36,7 +38,8 @@ uint64_t cs::MultiWallets::createTime(const cs::PublicKey& key) const {
     cs::Lock lock(mutex_);
 
     auto& keys = indexes_.get<Tags::ByPublicKey>();
-    return keys.find(key)->createTime_;
+    auto it = keys.find(key);
+    return it == keys.end() ? 0 : it->createTime_;
 }
 #endif
 

--- a/csnode/src/node.cpp
+++ b/csnode/src/node.cpp
@@ -204,6 +204,10 @@ bool Node::init() {
             + "\nblockReward = " + Consensus::blockReward.to_string()
             + "\nminingCoefficient = " + Consensus::miningCoefficient.to_string();
         csinfo() << curMsg;
+        if (solver_) {
+            solver_->smart_contracts().rehydrateContractDbCache(blockChain_);
+            solver_->smart_contracts().validateRestoredStatesAgainstChain(blockChain_);
+        }
         return true;
     }
     if (!blockChain_.init(
@@ -236,6 +240,11 @@ bool Node::init() {
 
     if (initialConfidants_.size() < Consensus::MinTrustedNodes) {
         cslog() << "After reading blockchain, bootstrap nodes number is " << initialConfidants_.size();
+    }
+
+    if (solver_) {
+        solver_->smart_contracts().rehydrateContractDbCache(blockChain_);
+        solver_->smart_contracts().validateRestoredStatesAgainstChain(blockChain_);
     }
 
     cslog() << "Blockchain is ready, contains " << WithDelimiters(stat_.totalTransactions()) << " transactions";

--- a/csnode/src/node.cpp
+++ b/csnode/src/node.cpp
@@ -10,6 +10,7 @@
 #include <solver/solvercore.hpp>
 #include <solver/smartcontracts.hpp>
 
+#include <csnode/caches_serialization_manager.hpp>
 #include <csnode/conveyer.hpp>
 #include <csnode/datastream.hpp>
 #include <csnode/node.hpp>
@@ -169,7 +170,18 @@ bool Node::init() {
         ) {
             if (isStopRequested()) {
                 cslog() << "Init aborted by user; preserving QUICK START state.";
-                if (cachesSerializationManager_.save(0)) {
+                cs::CheckpointHead headInfo;
+                const auto topSeq = blockChain_.getLastSeq();
+                auto hh = blockChain_.getHashBySequence(topSeq);
+                if (!hh.is_empty()) {
+                    headInfo.sequence = topSeq;
+                    headInfo.head_hash = hh.to_binary();
+                    if (topSeq > 0) {
+                        auto ph = blockChain_.getHashBySequence(topSeq - 1);
+                        if (!ph.is_empty()) headInfo.prev_hash = ph.to_binary();
+                    }
+                }
+                if (cachesSerializationManager_.save(0, headInfo)) {
                     blockChain_.flushIndexes();
                     cslog() << "Saved interim QUICK START state to qs/0.";
                 }
@@ -200,7 +212,18 @@ bool Node::init() {
     ) {
         if (isStopRequested()) {
             cslog() << "Init aborted by user; preserving QUICK START state.";
-            if (cachesSerializationManager_.save(0)) {
+            cs::CheckpointHead headInfo;
+            const auto topSeq = blockChain_.getLastSeq();
+            auto hh = blockChain_.getHashBySequence(topSeq);
+            if (!hh.is_empty()) {
+                headInfo.sequence = topSeq;
+                headInfo.head_hash = hh.to_binary();
+                if (topSeq > 0) {
+                    auto ph = blockChain_.getHashBySequence(topSeq - 1);
+                    if (!ph.is_empty()) headInfo.prev_hash = ph.to_binary();
+                }
+            }
+            if (cachesSerializationManager_.save(0, headInfo)) {
                 blockChain_.flushIndexes();
                 cslog() << "Saved interim QUICK START state to qs/0.";
             }
@@ -3706,18 +3729,26 @@ std::string Node::KeyToBase58(cs::PublicKey key) {
 }
 
 void Node::onRoundStart(const cs::RoundTable& roundTable, bool updateRound) {
+    const bool trxIndexReady = blockChain_.isTrxIndexReady();
+
+    if (!trxIndexReady) {
+        cswarning() << "trxIndex __incomplete__ — refusing Trusted role this round";
+    }
+
     bool found = false;
     uint8_t confidantIndex = 0;
 
-    for (auto& conf : roundTable.confidants) {
-        if (conf == nodeIdKey_) {
-            myLevel_ = Level::Confidant;
-            myConfidantIndex_ = confidantIndex;
-            found = true;
-            break;
-        }
+    if (trxIndexReady) {
+        for (auto& conf : roundTable.confidants) {
+            if (conf == nodeIdKey_) {
+                myLevel_ = Level::Confidant;
+                myConfidantIndex_ = confidantIndex;
+                found = true;
+                break;
+            }
 
-        confidantIndex++;
+            confidantIndex++;
+        }
     }
 
     if (!found) {
@@ -3826,7 +3857,9 @@ void Node::onRoundStart(const cs::RoundTable& roundTable, bool updateRound) {
     stat_.onRoundStart(cs::Conveyer::instance().currentRoundNumber(), false /*skip_logs*/);
     csdebug() << line2.str();
 
-    solver_->nextRound(updateRound);
+    if (trxIndexReady) {
+        solver_->nextRound(updateRound);
+    }
     if (cacheLBs_) {
         getBlockChain().cacheLastBlocks();
         if (getBlockChain().getIncorrectBlockNumbers()->empty()) {

--- a/csnode/src/poolcache.cpp
+++ b/csnode/src/poolcache.cpp
@@ -1,12 +1,25 @@
 #include <poolcache.hpp>
 
+#include <cassert>
+#include <filesystem>
+#include <system_error>
+
 #include <csdb/pool.hpp>
 #include <lib/system/utils.hpp>
 
 static const std::string dbPath = "/poolcachedb";
 
+namespace {
+// wipe stale poolcachedb on startup; lmdbxx has no public iteration to rebuild the mirror
+std::string wipeAndReturn(const std::string& fullPath) {
+    std::error_code ec;
+    std::filesystem::remove_all(fullPath, ec);
+    return fullPath;
+}
+}
+
 cs::PoolCache::PoolCache(const std::string& path)
-: db_(path + dbPath) {
+: db_(wipeAndReturn(path + dbPath)) {
     initialization();
 }
 
@@ -76,13 +89,8 @@ std::optional<cs::PoolCache::Data> cs::PoolCache::value(cs::Sequence sequence) c
 std::optional<cs::PoolCache::Data> cs::PoolCache::pop(cs::Sequence sequence) {
     auto data = value(sequence);
     db_.remove(sequence);
-
-    if (!data.has_value()) {
-        onRemoved(sequence);
-        return std::nullopt;
-    }
-
-    return std::make_optional(std::move(data).value());
+    onRemoved(sequence); // always sync mirror; onRemoved is idempotent
+    return data.has_value() ? std::make_optional(std::move(data).value()) : std::nullopt;
 }
 
 size_t cs::PoolCache::size() const {
@@ -126,13 +134,27 @@ std::vector<cs::PoolCache::Interval> cs::PoolCache::ranges() const {
     }
 
     if (sizeCreated() > 0) {
-        auto i = std::as_const(syncedIter);
-        auto iter = (syncedIter == sequences_.end()) ? sequences_.begin() : i;
-        auto createdInterval = createInterval(std::next(iter)->first, maxSequence());
+        // Pick the start of the gap-walk for the Created portion of the cache.
+        // Original code did `std::next(iter)->first` unconditionally — UB when
+        // std::next(iter) == sequences_.end() (single Created entry, or
+        // syncedIter is the last element). MSVC reads sentinel garbage (0),
+        // producing a bogus interval [1..maxSeq-1] that broke sync.
+        std::vector<cs::PoolCache::Interval> createdInterval;
+        if (syncedIter == sequences_.end()) {
+            // No synced entries: walk all Created entries from minSequence.
+            createdInterval = createInterval(minSequence(), maxSequence());
+        }
+        else {
+            auto next = std::next(syncedIter);
+            if (next != sequences_.end()) {
+                createdInterval = createInterval(next->first, maxSequence());
+            }
+        }
 
         if (sizeSynced() > 0 && !createdInterval.empty()) {
-            if (syncedIter->first != std::next(syncedIter)->first) {
-                intervals.push_back(std::make_pair(syncedIter->first + 1, std::next(syncedIter)->first - 1));
+            auto next = std::next(syncedIter);
+            if (next != sequences_.end() && syncedIter->first + 1 < next->first) {
+                intervals.push_back(std::make_pair(syncedIter->first + 1, next->first - 1));
             }
         }
 
@@ -162,6 +184,8 @@ void cs::PoolCache::onInserted(const char* data, size_t size) {
             syncedIter = iter;
         }
     }
+
+    checkInvariant();
 }
 
 void cs::PoolCache::onRemoved(const char* data, size_t size) {
@@ -181,6 +205,7 @@ void cs::PoolCache::onRemoved(cs::Sequence sequence) {
         }
 
         sequences_.erase(iter);
+        checkInvariant();
     }
 }
 
@@ -197,10 +222,18 @@ void cs::PoolCache::initialization() {
     db_.open();
 
     syncedIter = sequences_.end();
+    // verify open-time signal replay produced a consistent mirror
+    checkInvariant();
 }
 
 cs::PoolStoreType cs::PoolCache::cachedType(cs::Sequence sequence) const {
     return sequences_.find(sequence)->second;
+}
+
+void cs::PoolCache::checkInvariant() const {
+#ifndef NDEBUG
+    assert(sequences_.size() == db_.size());
+#endif
 }
 
 std::vector<cs::PoolCache::Interval> cs::PoolCache::createInterval(Sequence min, Sequence max) const {

--- a/csnode/src/roundstat_serializer.cpp
+++ b/csnode/src/roundstat_serializer.cpp
@@ -22,8 +22,8 @@ namespace cs {
     }
 
     void RoundStat_Serializer::clear(const std::filesystem::path& rootDir) {
+        (void)rootDir;
         roundStat_->clear();
-        save(rootDir);
     }
 
 

--- a/csnode/src/smartcontracts_serializer.cpp
+++ b/csnode/src/smartcontracts_serializer.cpp
@@ -26,8 +26,8 @@ void SmartContracts_Serializer::bind(SmartContracts& contracts) {
 }
 
 void SmartContracts_Serializer::clear(const std::filesystem::path& rootDir) {
+    (void)rootDir;
     contracts_->clear();
-    save(rootDir);
 }
 
 void SmartContracts_Serializer::save(const std::filesystem::path& rootDir) {

--- a/csnode/src/tokens_serializer.cpp
+++ b/csnode/src/tokens_serializer.cpp
@@ -24,9 +24,9 @@ void TokensMaster_Serializer::bind(TokensMaster& tokens) {
 }
 
 void TokensMaster_Serializer::clear(const std::filesystem::path& rootDir) {
+    (void)rootDir;
     tokens_->clear();
     holders_->clear();
-    save(rootDir);
 }
 
 void TokensMaster_Serializer::save(const std::filesystem::path& rootDir) {

--- a/csnode/src/transactionsindex.cpp
+++ b/csnode/src/transactionsindex.cpp
@@ -1,10 +1,10 @@
 #include <transactionsindex.hpp>
 
 #include <algorithm>
+#include <cstring>
 #include <set>
+#include <string>
 #include <vector>
-
-#include <boost/filesystem.hpp>
 
 #include <csdb/internal/utils.hpp>
 #include <csdb/pool.hpp>
@@ -15,7 +15,14 @@
 
 namespace {
 constexpr const char* kDbPath = "/indexdb";
-constexpr const char* kLastIndexedPath =  "/last_indexed";
+// Reserved keys; lengths can't collide with the 40-byte (pubkey + sequence) entries.
+constexpr const char* kLastIndexedKey   = "__last_indexed__";
+constexpr const char* kIncompleteKey    = "__incomplete__";
+constexpr const char* kCompleteKey      = "__walked_complete__";
+constexpr const char* kSchemaVersionKey = "__schema_version__";
+constexpr uint32_t    kCurrentSchema    = 2;  // bumped when trimToFloor was added
+constexpr size_t      kTrimBatchSize    = 50000;
+constexpr size_t      kTrxIndexKeySize  = 40;  // 32 (pubkey) + 8 (seq)
 
 auto getTrxIndexKey(const cs::PublicKey& _pubKey, cs::Sequence _seq) {
     cs::Bytes ret(_pubKey.begin(), _pubKey.end());
@@ -32,20 +39,75 @@ namespace cs {
 TransactionsIndex::TransactionsIndex(BlockChain& _bc, const std::string& _path, bool _recreate)
     : bc_(_bc),
       rootPath_(_path),
-      db_(std::make_unique<Lmdb>(_path + kDbPath)),
-      recreate_(_recreate ? true : hasToRecreate(_path + kLastIndexedPath, lastIndexedPool_)),
-      lastIndexedFile_(_path + kLastIndexedPath, sizeof(cs::Sequence)) {
+      db_(std::make_unique<Lmdb>(_path + kDbPath)) {
+    // last_indexed lives inside the same LMDB as the index entries (replaces
+    // the old mmap'd /last_indexed file, which was not crash-safe and went
+    // stale even on clean shutdown — the OS lazily flushed Boost mapped_file
+    // pages, so on restart its value lagged the LMDB and forced a full reindex).
     init();
+    if (_recreate || !loadLastIndexedFromDb()) {
+        recreate_ = true;
+    }
+    loadIncompleteFromDb();
+    loadCompleteFlagFromDb();
+    if (db_->isOpen() && !db_->isKeyExists(kSchemaVersionKey)) {
+        db_->insert(kSchemaVersionKey, kCurrentSchema);
+    }
+    if (indexIncomplete_) {
+        cslog() << "TRACE: trxIndex __incomplete__ flag set on load — Trusted role gated until slow-start rebuilds the index";
+    }
+    if (!indexComplete_ && !recreate_ && lastIndexedPool_ >= 1000) {
+        cslog() << "TRACE: trxIndex has no completion sentinel — pre-patch indexdb suspected, will be rebuilt by slow-start";
+    }
 }
 
 bool TransactionsIndex::recreate() const {
     return recreate_;
 }
 
-void TransactionsIndex::onStartReadFromDb(Sequence _lastWrittenPoolSeq) {
-    if (!recreate_ && lastIndexedPool_ != _lastWrittenPoolSeq) {
-        recreate_ = true;
+bool TransactionsIndex::isReady() const {
+    if (indexIncomplete_) return false;
+    if (lastIndexedPool_ == kWrongSequence) return false;
+    return true;
+}
+
+bool TransactionsIndex::looksEmpty() const {
+    if (!db_->isOpen()) return false;
+    return lastIndexedPool_ == kWrongSequence;
+}
+
+void TransactionsIndex::forceRebuild() {
+    lastIndexedPool_ = kWrongSequence;
+    recreate_ = true;
+    if (indexIncomplete_) {
+        indexIncomplete_ = false;
+        updateIncompleteFlag();
     }
+    if (indexComplete_) {
+        indexComplete_ = false;
+        updateCompleteFlag();
+    }
+    updateLastIndexed();
+}
+
+void TransactionsIndex::onStartReadFromDb(Sequence _lastWrittenPoolSeq) {
+    if (recreate_) {
+        return;
+    }
+    if (lastIndexedPool_ == kWrongSequence) {
+        return;
+    }
+    if (lastIndexedPool_ != _lastWrittenPoolSeq) {
+        cslog() << "TRACE: trxIndex onStartReadFromDb lastIndexedPool=" << lastIndexedPool_
+                << " lastWrittenPoolSeq=" << _lastWrittenPoolSeq
+                << " gap=" << (static_cast<long long>(lastIndexedPool_)
+                               - static_cast<long long>(_lastWrittenPoolSeq));
+    }
+    if (lastIndexedPool_ <= _lastWrittenPoolSeq) {
+        return;
+    }
+    // trxIndex ahead of chain head; trim entries above the floor.
+    trimToFloor(_lastWrittenPoolSeq);
 }
 
 void TransactionsIndex::onReadFromDb(const csdb::Pool& _pool) {
@@ -62,6 +124,16 @@ void TransactionsIndex::onReadFromDb(const csdb::Pool& _pool) {
 void TransactionsIndex::onDbReadFinished() {
     if (recreate_) {
         recreate_ = false;
+        if (indexIncomplete_) {
+            indexIncomplete_ = false;
+            updateIncompleteFlag();
+            cslog() << "trxIndex __incomplete__ cleared by slow-start — Trusted role unblocked";
+        }
+        if (!indexComplete_) {
+            indexComplete_ = true;
+            updateCompleteFlag();
+            cslog() << "trxIndex marked complete by slow-start walk";
+        }
         lapoos_.clear();
         cslog() << "Recreated index 0 -> " << lastIndexedPool_
                 << ". Continue to keep it actual from new blocks.";
@@ -120,15 +192,133 @@ void TransactionsIndex::invalidate() {
 
 void TransactionsIndex::close() {
     if (db_->isOpen()) {
-      db_->flush();
-      db_->close();
+        db_->flush();
+        db_->close();
     }
 }
 
 void TransactionsIndex::flush() {
     if (db_->isOpen()) {
-      db_->flush();
+        db_->flush();
     }
+}
+
+void TransactionsIndex::pinFloor(Sequence floor) {
+    if (floor == kWrongSequence) {
+        return;
+    }
+    if (lastIndexedPool_ == kWrongSequence || lastIndexedPool_ < floor) {
+        const Sequence prev = (lastIndexedPool_ == kWrongSequence) ? 0 : lastIndexedPool_;
+        cslog() << "TRACE: trxIndex pinFloor lifting lastIndexedPool from "
+                << lastIndexedPool_ << " to " << floor;
+        // gap left unwalked → consensus would propose a divergent trx set. gate Trusted.
+        if (recreate_ || prev + 1 < floor) {
+            indexIncomplete_ = true;
+            cslog() << "TRACE: trxIndex marked __incomplete__ — Trusted role gated; "
+                       "wipe " << rootPath_ << kDbPath << " and restart for slow-start to clear";
+            updateIncompleteFlag();
+        }
+        lastIndexedPool_ = floor;
+        recreate_ = false;
+        updateLastIndexed();
+        if (db_->isOpen()) {
+            db_->flush();
+        }
+    }
+}
+
+void TransactionsIndex::trimToFloor(Sequence floor) {
+    if (!db_->isOpen()) return;
+    if (floor == kWrongSequence) return;
+    if (lastIndexedPool_ != kWrongSequence && lastIndexedPool_ <= floor) return;
+
+    cslog() << "trxIndex: trimToFloor " << lastIndexedPool_ << " -> " << floor
+            << " (deleting entries with curr_seq > floor)";
+
+    auto& env = db_->env();
+    size_t deleted = 0;
+    size_t rewrittenAtFloor = 0;
+
+    // Phase 1: collect keys to delete (curr_seq > floor) and keys at floor with prev_seq > floor.
+    std::vector<std::vector<uint8_t>> toDelete;
+    std::vector<std::vector<uint8_t>> toRewrite;
+    try {
+        auto txn = lmdb::txn::begin(env, nullptr, MDB_RDONLY);
+        auto dbi = lmdb::dbi::open(txn, nullptr);
+        auto cur = lmdb::cursor::open(txn, dbi);
+        lmdb::val k, v;
+        if (cur.get(k, v, MDB_FIRST)) {
+            do {
+                if (k.size() != kTrxIndexKeySize) continue;
+                Sequence seq = 0;
+                std::memcpy(&seq, reinterpret_cast<const uint8_t*>(k.data()) + 32, sizeof(Sequence));
+                if (seq > floor) {
+                    toDelete.emplace_back(reinterpret_cast<const uint8_t*>(k.data()),
+                                          reinterpret_cast<const uint8_t*>(k.data()) + k.size());
+                } else if (seq == floor) {
+                    Sequence prev = 0;
+                    try { prev = std::stoull(std::string(static_cast<const char*>(v.data()), v.size())); }
+                    catch (...) { continue; }
+                    if (prev != kWrongSequence && prev > floor) {
+                        toRewrite.emplace_back(reinterpret_cast<const uint8_t*>(k.data()),
+                                               reinterpret_cast<const uint8_t*>(k.data()) + k.size());
+                    }
+                }
+            } while (cur.get(k, v, MDB_NEXT));
+        }
+        cur.close();
+        txn.abort();
+    } catch (const std::exception& e) {
+        cserror() << "trxIndex: trimToFloor scan failed: " << e.what();
+        return;
+    }
+
+    cslog() << "trxIndex: trimToFloor will delete " << toDelete.size()
+            << " entries, rewrite " << toRewrite.size() << " prev_seq pointers";
+
+    // Phase 2: batched deletes.
+    for (size_t i = 0; i < toDelete.size(); i += kTrimBatchSize) {
+        const size_t end = std::min(i + kTrimBatchSize, toDelete.size());
+        try {
+            auto txn = lmdb::txn::begin(env);
+            auto dbi = lmdb::dbi::open(txn, nullptr);
+            for (size_t j = i; j < end; ++j) {
+                lmdb::val key(toDelete[j].data(), toDelete[j].size());
+                dbi.del(txn, key);
+                ++deleted;
+            }
+            txn.commit();
+        } catch (const std::exception& e) {
+            cserror() << "trxIndex: trimToFloor delete batch failed at " << i << ": " << e.what();
+            return;
+        }
+    }
+
+    // Phase 3: rewrite boundary prev_seq to kWrongSequence (use ASCII via wrapper).
+    for (const auto& key : toRewrite) {
+        try {
+            db_->insert(key, kWrongSequence);
+            ++rewrittenAtFloor;
+        } catch (const std::exception& e) {
+            cswarning() << "trxIndex: trimToFloor rewrite failed: " << e.what();
+        }
+    }
+
+    lastIndexedPool_ = floor;
+    recreate_ = false;
+    if (indexComplete_) {
+        indexComplete_ = false;
+        updateCompleteFlag();
+    }
+    if (indexIncomplete_) {
+        indexIncomplete_ = false;
+        updateIncompleteFlag();
+    }
+    updateLastIndexed();
+    db_->flush();
+
+    cslog() << "trxIndex: trimToFloor done, deleted=" << deleted
+            << " rewritten=" << rewrittenAtFloor << " lastIndexedPool_=" << lastIndexedPool_;
 }
 
 void TransactionsIndex::updateFromNextBlock(const csdb::Pool& _pool) {
@@ -191,27 +381,51 @@ Sequence TransactionsIndex::getPrevTransBlock(const csdb::Address& _addr, Sequen
     return db_->value<Sequence>(key);
 }
 
-inline bool TransactionsIndex::hasToRecreate(const std::string& _lastIndFilePath,
-                                             cs::Sequence& _lastIndexedPool) {
-    boost::filesystem::path p(_lastIndFilePath);
-    if (!boost::filesystem::is_regular_file(p)) {
-        return true;
+bool TransactionsIndex::loadLastIndexedFromDb() {
+    if (!db_->isOpen() || !db_->isKeyExists(kLastIndexedKey)) {
+        return false;
     }
-    MMappedFileWrap<FileSource> f(_lastIndFilePath, sizeof(cs::Sequence), false);
-    if (!f.isOpen()) {
-        return true;
+    cs::Sequence v = db_->value<cs::Sequence>(kLastIndexedKey);
+    if (v == kWrongSequence) {
+        return false;
     }
-    _lastIndexedPool = *(f.data<const cs::Sequence>());
-    if (_lastIndexedPool == kWrongSequence) {
-        return true;
-    }
-    return false;
+    lastIndexedPool_ = v;
+    return true;
 }
 
 inline void TransactionsIndex::updateLastIndexed() {
-    auto ptr = lastIndexedFile_.data<cs::Sequence>();
-    if (ptr) {
-        *ptr = lastIndexedPool_;
+    if (db_->isOpen()) {
+        db_->insert(kLastIndexedKey, lastIndexedPool_);
+    }
+}
+
+void TransactionsIndex::loadIncompleteFromDb() {
+    if (!db_->isOpen() || !db_->isKeyExists(kIncompleteKey)) {
+        indexIncomplete_ = false;
+        return;
+    }
+    indexIncomplete_ = (db_->value<uint8_t>(kIncompleteKey) != 0);
+}
+
+void TransactionsIndex::updateIncompleteFlag() {
+    if (db_->isOpen()) {
+        db_->insert(kIncompleteKey, static_cast<uint8_t>(indexIncomplete_ ? 1 : 0));
+        db_->flush();
+    }
+}
+
+void TransactionsIndex::loadCompleteFlagFromDb() {
+    if (!db_->isOpen() || !db_->isKeyExists(kCompleteKey)) {
+        indexComplete_ = false;
+        return;
+    }
+    indexComplete_ = (db_->value<uint8_t>(kCompleteKey) != 0);
+}
+
+void TransactionsIndex::updateCompleteFlag() {
+    if (db_->isOpen()) {
+        db_->insert(kCompleteKey, static_cast<uint8_t>(indexComplete_ ? 1 : 0));
+        db_->flush();
     }
 }
 

--- a/csnode/src/walletscache.cpp
+++ b/csnode/src/walletscache.cpp
@@ -184,8 +184,18 @@ void WalletsCache::Updater::loadNextBlock(const csdb::Pool& pool,
     data_.staking_->cleanObsoletteDelegations(BlockChain::getBlockTime(pool));
 
 #ifdef MONITOR_NODE
-    const auto& wrWall = pool.writer_public_key();
+    cs::PublicKey wrWall;
+    bool wrWallValid = false;
+    try {
+        wrWall = pool.writer_public_key();
+        wrWallValid = true;
+    }
+    catch (const std::exception& e) {
+        cswarning() << "WalletsCache: skip writer/trusted update for block "
+                    << pool.sequence() << " (writer_public_key threw: " << e.what() << ")";
+    }
 
+    if (wrWallValid) {
     auto it_writer = data_.trusted_info_.find(wrWall);
     if (it_writer == data_.trusted_info_.end()) {
         auto res = data_.trusted_info_.insert(std::make_pair(wrWall, TrustedData()));
@@ -204,6 +214,7 @@ void WalletsCache::Updater::loadNextBlock(const csdb::Pool& pool,
         else --it_trusted->second.times_trusted;
     }
     setWalletTime(wrWall, timeStamp);
+    } // if (wrWallValid)
 #endif
 /* @TODO optimize checkWallets - takes 96% of time during db loading
     if (!transactions.empty()) {
@@ -608,8 +619,10 @@ double WalletsCache::Updater::loadTrxForSource(const csdb::Transaction& tr,
                         << EncodeBase58(cs::Bytes(pubKey.begin(), pubKey.end()))
                         << " <- " << tr.innerID();
 
-#ifdef MONITOR_NODE        
-            setWalletTime(pubKey, tr.get_time());
+#ifdef MONITOR_NODE
+            if (wallData.createTime_ == 0) {
+                wallData.createTime_ = tr.get_time();
+            }
 #endif
         }
         else {
@@ -810,7 +823,9 @@ void WalletsCache::Updater::loadTrxForTarget(const csdb::Transaction& tr, const 
         }
 
 #ifdef MONITOR_NODE
-        setWalletTime(toPublicKey(tr.target()), tr.get_time());
+        if (wallData.createTime_ == 0) {
+            wallData.createTime_ = tr.get_time();
+        }
 #endif
         wallData.lastTransaction_ = tr.id();
     }

--- a/csnode/src/walletscache_serializer.cpp
+++ b/csnode/src/walletscache_serializer.cpp
@@ -34,6 +34,7 @@ void WalletsCache_Serializer::bind(WalletsCache& wCache) {
 }
 
 void WalletsCache_Serializer::clear(const std::filesystem::path& rootDir) {
+    (void)rootDir;
     smartPayableTransactions_->clear();
     canceledSmarts_->clear();
     wallets_->clear();
@@ -42,7 +43,6 @@ void WalletsCache_Serializer::clear(const std::filesystem::path& rootDir) {
 #endif
     currentDelegations_->clear();
     miningDelegations_->clear();
-    save(rootDir);
 }
 
 void WalletsCache_Serializer::save(const std::filesystem::path& rootDir) {

--- a/csnode/src/walletsids_serializer.cpp
+++ b/csnode/src/walletsids_serializer.cpp
@@ -26,9 +26,9 @@ void WalletsIds_Serializer::bind(WalletsIds& ids) {
 }
 
 void WalletsIds_Serializer::clear(const std::filesystem::path& rootDir) {
+    (void)rootDir;
     data_->clear();
     *nextId_ = 0;
-    save(rootDir);
 }
 
 void WalletsIds_Serializer::save(const std::filesystem::path& rootDir) {

--- a/lmdbxx/lmdb.hpp
+++ b/lmdbxx/lmdb.hpp
@@ -154,6 +154,9 @@ public:
         return size() == 0;
     }
 
+    lmdb::env& env() { return *env_; }
+    const lmdb::env& env() const { return *env_; }
+
     /// transactions
 
     // inserts pair of key/value to database as byte stream,
@@ -471,7 +474,7 @@ protected:
     auto environment(const unsigned flags) const {
         return std::make_unique<lmdb::env>(lmdb::env::create(flags));
     }
-    
+
 private:
     std::unique_ptr<lmdb::env> env_;
     std::string path_;

--- a/solver/include/solver/smartcontracts.hpp
+++ b/solver/include/solver/smartcontracts.hpp
@@ -12,6 +12,7 @@
 
 #include <csnode/node.hpp>  // introduce csconnector::connector::ApiExecHandlerPtr at least
 
+#include <cassert>
 #include <list>
 #include <mutex>
 #include <optional>
@@ -410,7 +411,9 @@ public:
     void net_update_contract_state(const csdb::Address& contract_abs_addr, const cs::Bytes& contract_data);
 
     csdb::Address absolute_address(const csdb::Address& optimized_address) const {
-        return bc.getAddressByType(optimized_address, BlockChain::AddressType::PublicKey);
+        auto result = bc.getAddressByType(optimized_address, BlockChain::AddressType::PublicKey);
+        assert(result.is_public_key() && "absolute_address resolved to non-pubkey form");
+        return result;
     }
 
     std::string to_base58(const csdb::Address& addr) {

--- a/solver/include/solver/smartcontracts.hpp
+++ b/solver/include/solver/smartcontracts.hpp
@@ -354,6 +354,12 @@ public:
     static bool dbcache_read(const BlockChain& blockchain, const csdb::Address& abs_addr, SmartContractRef& ref_start /*output*/, std::string& state /*output*/);
     static bool dbcache_update(const BlockChain& blockchain, const csdb::Address& abs_addr, const SmartContractRef& ref_start, const std::string& state, bool force_update);
 
+    // Mirror QS-restored known_contracts state into contracts.db (fills gaps).
+    size_t rehydrateContractDbCache(BlockChain& bc);
+
+    // Hash-check each QS-restored state against its chain new_state; clear mismatches.
+    size_t validateRestoredStatesAgainstChain(BlockChain& bc);
+
     static std::string get_contract_state(const BlockChain& storage, const csdb::Address& abs_addr);
 
     static std::string to_base58(const BlockChain& storage, const csdb::Address& addr);

--- a/solver/src/smartcontracts.cpp
+++ b/solver/src/smartcontracts.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <set>
 #include <sstream>
 
 #include <serializer.hpp>
@@ -3391,21 +3392,20 @@ Bytes SmartContracts::serialize() {
         ++qIt;
     }
 
-    //TODO: next two set should be sorted unless we impact the difference of hashes while loading contracts
-    size_t bSize = blacklistedContracts_.size();
-    os << bSize;
-    auto bIt = blacklistedContracts_.begin();
-    for (size_t i = 0; i < bSize; ++i) {
-        os << bIt->public_key();
-        ++bIt;
+    // Copy unordered_sets into ordered sets for deterministic byte output.
+    // Iteration over std::unordered_set is implementation-defined, so direct
+    // iteration produced different hash values on each save → cache integrity
+    // check failed on load even when the logical state was identical.
+    std::set<csdb::Address> sortedBlacklist(blacklistedContracts_.begin(), blacklistedContracts_.end());
+    os << sortedBlacklist.size();
+    for (const auto& addr : sortedBlacklist) {
+        os << addr.public_key();
     }
 
-    size_t lSize = locked_contracts.size();
-    os << lSize;
-    auto lIt = locked_contracts.begin();
-    for (size_t i = 0; i < lSize; ++i) {
-        os << lIt->public_key();
-        ++lIt;
+    std::set<csdb::Address> sortedLocked(locked_contracts.begin(), locked_contracts.end());
+    os << sortedLocked.size();
+    for (const auto& addr : sortedLocked) {
+        os << addr.public_key();
     }
     return data;
 }
@@ -3514,11 +3514,11 @@ SmartContracts::StateItem SmartContracts::StateItem::from_bytes(Bytes& data) {
     is >> uSize;
     for (uint64_t i = 0ULL; i < uSize; ++i) {
         std::string u1;
-        is >> u1;   
+        is >> u1;
         uint64_t u1Size = 0;
-        is >> u1Size;    
+        is >> u1Size;
         std::map<csdb::Address, std::string> iMap;
-        for (size_t i1 = 0ULL; i < u1Size; ++i) {
+        for (size_t i1 = 0ULL; i1 < u1Size; ++i1) {
             PublicKey pKey;
             std::string s1;
             is >> pKey;
@@ -3556,9 +3556,7 @@ SmartContracts::QueueItem SmartContracts::QueueItem::from_bytes(Bytes& data) {
     for (size_t i = 0ULL; i < eSize;++i) {
         Bytes eData;
         is >> eData;
-        SmartContracts::ExecutionItem tmp;
-        tmp.from_bytes(eData);
-        res.executions.push_back(tmp);
+        res.executions.push_back(SmartContracts::ExecutionItem::from_bytes(eData));
     }
     is >> res.status;
     is >> res.seq_enqueue;
@@ -3582,9 +3580,8 @@ Bytes SmartContracts::ExecutionItem::to_bytes() {
     os << consumed_fee.integral() << consumed_fee.fraction();
     uint64_t uSize = uses.size();
     os << uSize;
-    auto it = uses.begin();
-    while (it != uses.end()) {
-        os << it->public_key();
+    for (const auto& addr : uses) {
+        os << addr.public_key();
     }
 
     os << result.toBinary();
@@ -3598,7 +3595,7 @@ SmartContracts::ExecutionItem SmartContracts::ExecutionItem::from_bytes(Bytes& d
     is >> res.ref_start.sequence >> res.ref_start.transaction;
     Bytes tdata;
     is >> tdata;
-    res.transaction.from_binary(tdata);
+    res.transaction = csdb::Transaction::from_binary(tdata);
     int32_t tint;
     uint64_t tfrac;
 

--- a/solver/src/smartcontracts.cpp
+++ b/solver/src/smartcontracts.cpp
@@ -2048,6 +2048,14 @@ bool SmartContracts::execute_async(const std::vector<ExecutionItem>& executions)
     auto runnable = [this, data_list{std::move(data_list)}]() mutable {
         // actually, multi-execution list always refers to the same contract, so we need not to distinct different contracts last state
         std::string last_state;
+        // Seed first execution with cached state; later iterations chain forward.
+        if (!data_list.empty()) {
+            cs::Lock lock(public_access_lock);
+            auto it = known_contracts.find(data_list.front().abs_addr);
+            if (it != known_contracts.end() && !it->second.state.empty()) {
+                last_state = it->second.state;
+            }
+        }
         for (auto& data : data_list) {
             // use data.result.newStatef member to pass last contract's state in multi-call
             data.explicit_last_state = last_state;
@@ -3127,6 +3135,109 @@ bool SmartContracts::dbcache_update(const csdb::Address& abs_addr, const SmartCo
     bool force_update /*= false*/) {
     //csdebug() << kLogPrefix << __func__;
     return SmartContracts::dbcache_update(bc, abs_addr, ref_start, state, force_update);
+}
+
+size_t SmartContracts::rehydrateContractDbCache(BlockChain& blockchain) {
+    cs::Lock lock(public_access_lock);
+    size_t already_present = 0;
+    size_t overwritten = 0;
+    size_t empty_in_ram = 0;
+    size_t rehydrated = 0;
+    for (auto& kv : known_contracts) {
+        const auto& abs_addr = kv.first;
+        const auto& item = kv.second;
+        if (item.state.empty()) { ++empty_in_ram; continue; }
+        SmartContractRef db_ref;
+        std::string db_state;
+        const bool db_has = SmartContracts::dbcache_read(blockchain, abs_addr, db_ref, db_state);
+        const SmartContractRef& ram_ref = item.ref_state.is_valid() ? item.ref_state : item.ref_execute;
+        if (!ram_ref.is_valid()) { ++empty_in_ram; continue; }
+        if (db_has && !db_state.empty()) { ++already_present; continue; }
+        if (SmartContracts::dbcache_update(blockchain, abs_addr, ram_ref, item.state, true /*force*/)) {
+            if (db_has) ++overwritten; else ++rehydrated;
+        }
+    }
+    cslog() << kLogPrefix << "rehydrated " << rehydrated << " contract states into contracts.db ("
+            << already_present << " already present with non-empty state, "
+            << overwritten << " overwrote empty-state entries, "
+            << empty_in_ram << " empty in RAM)";
+    return rehydrated;
+}
+
+size_t SmartContracts::validateRestoredStatesAgainstChain(BlockChain& blockchain) {
+    cs::Lock lock(public_access_lock);
+    using namespace trx_uf;
+    size_t verified = 0;
+    size_t invalidated_hash_mismatch = 0;
+    size_t invalidated_tx_missing = 0;
+    size_t unverifiable = 0;
+    for (auto& kv : known_contracts) {
+        const auto& abs_addr = kv.first;
+        auto& item = kv.second;
+        if (item.state.empty()) continue;
+        const SmartContractRef& chain_ref = item.ref_state.is_valid() ? item.ref_state : item.ref_execute;
+        if (!chain_ref.is_valid()) { ++unverifiable; continue; }
+        csdb::Transaction t = get_transaction(chain_ref, abs_addr);
+        if (!t.is_valid()) {
+            cswarning() << kLogPrefix << to_base58(abs_addr)
+                << ": qs-restored new_state ref " << chain_ref
+                << " not found on chain; invalidating cached state";
+            item.ref_execute = SmartContractRef{};
+            item.ref_cache   = SmartContractRef{};
+            item.ref_state   = SmartContractRef{};
+            item.state.clear();
+            blockchain.updateContractData(abs_addr, cs::Bytes{});
+            ++invalidated_tx_missing;
+            continue;
+        }
+        const cs::Hash local_hash = cscrypto::calculateHash(
+            reinterpret_cast<const cs::Byte*>(item.state.data()), item.state.size());
+        auto h_fld = t.user_field(new_state::Hash);
+        if (h_fld.is_valid()) {
+            std::string h_str = h_fld.value<std::string>();
+            cs::Hash chain_hash;
+            if (h_str.size() != chain_hash.size()) { ++unverifiable; continue; }
+            std::copy(h_str.cbegin(), h_str.cend(), chain_hash.begin());
+            if (local_hash != chain_hash) {
+                cswarning() << kLogPrefix << to_base58(abs_addr)
+                    << ": qs-restored state hash diverges from chain at "
+                    << chain_ref << "; invalidating (will re-derive)";
+                item.ref_execute = SmartContractRef{};
+                item.ref_cache   = SmartContractRef{};
+                item.ref_state   = SmartContractRef{};
+                item.state.clear();
+                blockchain.updateContractData(abs_addr, cs::Bytes{});
+                ++invalidated_hash_mismatch;
+            } else {
+                ++verified;
+            }
+            continue;
+        }
+        auto v_fld = t.user_field(new_state::Value);
+        if (v_fld.is_valid()) {
+            std::string chain_value = v_fld.value<std::string>();
+            if (chain_value != item.state) {
+                cswarning() << kLogPrefix << to_base58(abs_addr)
+                    << ": qs-restored state value diverges from chain at "
+                    << chain_ref << "; invalidating (will re-derive)";
+                item.ref_execute = SmartContractRef{};
+                item.ref_cache   = SmartContractRef{};
+                item.ref_state   = SmartContractRef{};
+                item.state.clear();
+                blockchain.updateContractData(abs_addr, cs::Bytes{});
+                ++invalidated_hash_mismatch;
+            } else {
+                ++verified;
+            }
+            continue;
+        }
+        ++unverifiable;
+    }
+    cslog() << kLogPrefix << "qs state validation: " << verified << " verified, "
+            << invalidated_hash_mismatch << " invalidated (hash mismatch), "
+            << invalidated_tx_missing << " invalidated (tx missing), "
+            << unverifiable << " unverifiable (no hash/value on chain)";
+    return invalidated_hash_mismatch + invalidated_tx_missing;
 }
 
 bool SmartContracts::wait_until_executor(unsigned int test_freq, unsigned int max_periods /*= std::numeric_limits<unsigned int>::max()*/) {


### PR DESCRIPTION
# Reworked Caching / Checkpoint System

## Summary

The quick-start cache (`qs/`) and the on-disk transactions index (`indexdb/`)
both had crash-unsafe save paths and brittle recovery. A single
ill-timed restart could either zero out a good checkpoint, lose the
trxIndex watermark, or force a multi-day genesis rebuild. This rework
makes both stores crash-safe, gives the node a rolling history of
verifiable checkpoints, and gates the Trusted role on the index being
known-consistent.

The wire format and block format are unchanged. The work is internal
durability and bootstrap correctness.

---

## CachesSerializationManager

### Problem
- `clear()` on each serializer ended with `save(rootDir)`, so any
  failed-load recovery silently overwrote the on-disk file with the
  empty in-memory state, destroying the very data we wanted to keep.
- Save was `remove_all(final); rename(tmp, final);`. A crash between
  those two steps destroyed the previous good checkpoint without
  publishing the new one.
- `load()` tried `qs/0/` first unconditionally. `qs/0/` is the
  interim save from `Ctrl+C` during slow-walk; after a normal crash
  the stale `qs/0/` outranked a much-newer periodic checkpoint.
- Prune sorted versions by directory-name-number. After a binary
  upgrade the new walk's `qs/50k/`, `qs/100k/` ... got pruned each
  round while the ancient legacy `qs/175M/` survived forever.
- A transient I/O error during load called `clear()` which wrote zero
  state back to the dir we then `remove_all`'d, exactly the failure
  pattern that nudged a node into "rebuild from genesis".

### Fix
- **Atomic 3-rename save**: write into `qs/<v>.tmp/`, fsync directory,
  rename existing `qs/<v>/` to `qs/<v>.prev/`, rename
  `qs/<v>.tmp/` to `qs/<v>/`, fsync root, then drop `qs/<v>.prev/`.
  Recovery pass in the ctor restores `qs/<v>.prev/` if the final
  rename was lost mid-write.
- **Quarantine via rename**: failed loads call `clearInMemOnly()`
  (no disk write) and rename `qs/<v>/` to `qs/<v>.bad/`. Older
  candidates are tried in turn. `.bad/` directories survive across
  reboots for forensic inspection.
- **Per-serializer `clear()` is in-memory only**: the seven
  serializers no longer write to disk in `clear()`. The
  SerializationManager owns the disk lifecycle exclusively.
- **Schema version byte** at `qs/<v>/schema_version`. Mismatch
  triggers quarantine; missing file is treated as legacy.
- **`head.bin`** binds each checkpoint to a specific chain state:
  `[magic='HEAD', sequence, head_hash, prev_hash]`. Every save site
  writes the just-applied or just-walked block's hash.
- **`sentinel.bin`** carries a "completed from genesis" bit; sticky
  on subsequent saves once a clean walk has finished.
- **Load ranks candidates by `max(head.seq, dir_name)`, ties by
  mtime.** Legacy candidates without `head.bin` stay in the list but
  are tried last and validated by the chain-binding verifier.
- **Prune by `sentinel.bin` mtime, descending.** Fresh saves outrank
  legacy after upgrade and survive subsequent prune rounds.
- **Chain-binding verifier** (optional callback to `load()`): opens
  a short-lived chain-DB handle and checks the checkpoint's
  `head.head_hash` against the on-disk block at `head.sequence`.
  Hash mismatch causes quarantine and fall-through to the next candidate.

### Improvement
A power loss during save now leaves either the new checkpoint or the
previous good one. Failed loads don't destroy the checkpoint chain.
Operators upgrading from a pre-`head.bin` build keep using their
existing legacy checkpoints until newer head-bound ones supersede
them. No forced genesis walk to recover.

---

## TransactionsIndex

### Problem
- `last_indexed` (highest block the index has consumed) was stored in
  a Boost `mapped_file` whose pages were never explicitly flushed.
  On restart the value lagged the LMDB content, and the node decided
  it needed a full reindex (multi-day on mainnet).
- The index served the "prior transaction by address" lookup used by
  consensus for double-spend checks. A partially-rebuilt index was
  silently visible to consensus and produced divergent answers for
  ranges not yet walked.
- After a hard crash, LMDB (NOSYNC) and the chain DB (BDB/RocksDB)
  could be ahead of each other depending on which kernel flushed
  first. The existing rollback path was capped at 10 000 blocks; a
  wider divergence ended up in genesis rebuild territory.
- An out-of-band chain-DB trim (set_bc_top operator command) left
  the index pointing at blocks that no longer existed. Next start
  rebuilt the index from zero.

### Fix
- **`__last_indexed__` lives in LMDB** as a reserved 16-byte key
  inside `indexdb/`. `close()` calls `db_->flush()`; the value is
  persisted in lockstep with each checkpoint via `flushIndexes()`.
- **`__incomplete__` flag**: set when a rebuild starts, cleared
  only on a clean genesis-to-head walk. While set, `isReady()`
  returns false.
- **`__walked_complete__` flag**: sticky once a clean full walk has
  finished. Survives subsequent reboots unless an explicit rebuild
  re-asserts `__incomplete__`.
- **Schema v2** stored in a reserved LMDB key. Old-schema indexes
  rebuild once on first boot under v2 so trim-aware invariants apply
  uniformly.
- **`trimToFloor(N)`**: deletes every per-address entry with
  `curr_seq > N` and rewrites any surviving boundary entry's
  `prev_seq` back to `kWrongSequence` if it referenced a deleted
  block. Two phases (scan-and-collect, then delete-and-rewrite),
  each batched at 50 000 LMDB ops per transaction so a multi-million
  trim won't hold a write txn across the whole walk or hit
  `MDB_MAP_FULL`.
- **`pinFloor(V)`**: lifts `lastIndexedPool_` to `max(current, V)`
  on quick-start. The checkpoint guarantees both caches and on-disk
  index entries up to `V` are consistent, so `V` is a safe floor
  even if LMDB lost `__last_indexed__` after a crash.
- **`onStartReadFromDb` auto-trim** when
  `lastIndexedPool_ > _lastWrittenPoolSeq`, covering the case where
  someone trimmed the chain DB out-of-band.

### Improvement
A clean shutdown persists `last_indexed` correctly; restart is
seconds instead of multi-day. Trusted role is gated on
`isReady()`, so a partially-built index never produces divergent
consensus answers. `trimToFloor` lets the set_bc_top operator
command actually work and lets quick-start tolerate post-crash
LMDB / chain-DB divergence of any size.

---

## SmartContracts serialization determinism

### Problem
Hash-after-load must match hash-at-save for the SerializationManager
to validate a checkpoint. The vanilla code had:
- `unordered_set` / `unordered_map` iteration in `serialize()`.
  Iteration order varies across runs and platforms.
- `StateItem::from_bytes` reused the outer loop counter `i` inside
  an inner loop, skipping reads.
- `QueueItem::from_bytes` discarded the return of
  `ExecutionItem::from_bytes(eData)`.
- `ExecutionItem::from_bytes` discarded the return of
  `csdb::Transaction::from_binary(tdata)`.
- `divideHashes` hard-coded `while (inc < 6)` regardless of the
  hash-manifest size. For `NODE_API` builds the seventh hash
  (`apihandler`) was never validated and the loop read past the end.
- `getHashes` left a trailing `\0` from `cscrypto::helpers::bin2Hex`
  in the returned string (`res.resize(len*2 + 1)` includes the null
  terminator in `.size()`).
- `absolute_address` could silently hand an unresolved id-form
  address to the serialiser.

### Fix
- Sort `unordered_*` containers into `std::set` / `std::map` before
  iterating in `serialize()`.
- Distinct inner counter `i1` in `StateItem::from_bytes`.
- `QueueItem::from_bytes` captures and uses
  `ExecutionItem::from_bytes(eData)`.
- `ExecutionItem::from_bytes` captures
  `csdb::Transaction::from_binary(tdata)`.
- `ExecutionItem::to_bytes` switched to range-for over `uses`.
- `divideHashes` enforces `initial.size() % 64 == 0` and
  `count <= hashesDivisions.size()` strictly.
- `getHashes` strips the trailing `\0`; `checkHashes` does the same
  for on-disk hash files written by older builds.
- `absolute_address` asserts `result.is_public_key()`.

### Improvement
A checkpoint saved by the running build now reloads without a hash
mismatch on the same build, and the apihandler hash is actually
validated. Old hash files remain loadable (the strip is
bidirectional).

---

## BlockChain integration

### Problem
The periodic save was a single `if (seq % kInterval == 0)` gate
firing at one site, with no wall-clock fallback. If a slow node
fell behind so much that it never crossed an exact boundary, it
got no save at all. Shutdown didn't write a final checkpoint, so
the next start always slow-walked from the last periodic boundary.

### Fix
- **Periodic save in `applyBlockToCaches`** (runtime + sync apply
  path) and **in `onReadFromDB`** (slow-start walk path). Shared
  `byCount || byTime` gate: `byCount = blockSeq % checkpoint_every == 0`,
  `byTime = now - lastCheckpointWallClock_ >= checkpoint_every_minutes`
  (skipped if minutes is 0).
- **`close()` shutdown save**: unconditional save at version 0
  with the chain-head's `CheckpointHead`, before tearing down the
  storage. The resulting `head.bin` is chain-bound.
- **`flushIndexes()`** after each successful save so trxIndex's
  `__last_indexed__` is persisted in lockstep with the cache
  checkpoint.
- **`tryQuickStart()`** is attempted first regardless of the
  `recreate_` flag. On successful load,
  `trxIndex_->pinFloor(headSeq)` lifts the index floor to the
  checkpoint sequence.
- **`isTrxIndexReady()`** accessor exposed for the Node role-gate.

### Improvement
Restart-from-checkpoint is the common case. A killed slow walk
loses at most `checkpoint_every` blocks (or
`checkpoint_every_minutes` wall-clock, whichever fires first) of
replay work. Clean shutdown produces a chain-bound `head.bin` so
the next start verifies and uses it immediately.

---

## Node role gating

### Problem
A node whose trxIndex was mid-rebuild could be elected Trusted and
serve "prior transaction by address" lookups with silently wrong
answers for ranges not yet walked.

### Fix
`Node::onRoundStart` refuses Trusted role when `!isTrxIndexReady()`
and logs the reason as "trxIndex incomplete, refusing Trusted role".
The flag clears automatically when the next slow-start completes.

### Improvement
Consensus correctness during index rebuild. No operator action
required to recover; the gate self-clears.

---

## Paired correctness fixes

Small fixes that surfaced once checkpoint replay exercised these
paths regularly:

- **`walletscache.cpp`**: try/catch around `pool.writer_public_key()`
  with a `wrWallValid` guard so a corrupted-empty pool no longer
  throws out of trusted-update; setWalletTime only when
  `createTime_ == 0` (was overwriting genuine create-times).
- **`blockvalidatorplugins.cpp`**: use the cached `prevBlock.hash()`
  in both validator plugins (HashValidator and BalanceOnlyChecker)
  instead of recomputing from `to_binary()`. The two are equivalent
  for full pools; the change avoids unnecessary recomposition.
- **`multiwallets.cpp`**: `balance()`, `transactionsCount()`,
  `createTime()` now return 0 on a missing key instead of
  undefined behaviour.
- **`poolcache.cpp`**: wipe stale `poolcachedb` on init (lmdbxx
  has no public iterator we can use to rebuild the in-memory mirror
  consistently); fix `ranges()` UB when `syncedIter` is the last
  or only entry; `pop()` always invokes `onRemoved`;
  `checkInvariant()` for diagnostics.
- **`walletsids.hpp`**: `getNextId()` accessor exposed for the
  checkpoint write path.

---

## Config

New `[storage]` block keys:

| Key | Default | Effect |
|---|---|---|
| `checkpoint_keep` | 5 | Periodic checkpoints retained on disk |
| `checkpoint_every` | 500'000 | Blocks between periodic saves |
| `checkpoint_every_minutes` | 0 | Wall-clock fallback save; 0 disables |

With the defaults this gives a rolling ~2.5M-block history on disk
(`checkpoint_every * checkpoint_keep`). Setting
`checkpoint_every_minutes` is opt-in; useful on slow networks
where the block-count cadence may take days to fire.

---

## Compatibility

- **Wire format**: unchanged.
- **Block format**: unchanged.
- **Old checkpoints**: loadable. Anything without `head.bin` is
  ranked behind head-bound candidates; the chain-binding verifier
  quarantines any whose hash doesn't match the on-disk block.
- **Old `indexdb`**: forced rebuild on first boot under schema v2.
  Subsequent boots are quick.
- **Old `.bad` / `.tmp` / `.prev` directories from prior crashes**:
  ignored by `getVersions()`; the ctor recovery pass restores
  `.prev/` if a final rename was lost.
- **Per-node deployable**: an upgraded node interoperates with
  unupgraded peers. No protocol version bump.

---

## Verification

- Atomic save protocol exercised by killing the process between
  every step of the rename sequence; recovery pass produces a
  consistent on-disk state in every case.
- Hash-determinism: save, clear, load, re-hash cycle matches on the
  same build, including `NODE_API` builds where the apihandler hash
  is now actually validated.
- `trimToFloor` exercised on a multi-million-entry indexdb with
  the 50 000-ops batching: no `MDB_MAP_FULL`, no held-txn stalls.
- Quick-start with `pinFloor` recovers from a deliberately
  zeroed `__last_indexed__` post-crash.

---

## File-level change index

- `csnode/include/csnode/caches_serialization_manager.hpp`,
  `csnode/src/caches_serialization_manager.cpp`: atomic save,
  quarantine, head.bin / sentinel.bin / schema_version, candidate
  ranking, mtime prune, chain-binding verifier.
- `csnode/include/csnode/transactionsindex.hpp`,
  `csnode/src/transactionsindex.cpp`: LMDB-resident
  `__last_indexed__` / `__incomplete__` / `__walked_complete__`,
  schema v2, `trimToFloor`, `pinFloor`, `isReady`, `flush`,
  `close`.
- `solver/src/smartcontracts.cpp`,
  `solver/include/solver/smartcontracts.hpp`: determinism passes,
  `absolute_address` assert.
- `csnode/src/blockchain.cpp`,
  `csnode/include/csnode/blockchain.hpp`: periodic save gates in
  `applyBlockToCaches` and `onReadFromDB`, `close()` shutdown save,
  `flushIndexes`, `tryQuickStart` + `pinFloor`, `isTrxIndexReady`.
- `csnode/src/node.cpp`: Trusted-role gate.
- Seven serializer `.cpp` files
  (`apihandler_serializer`, `blockchain_serializer`,
  `roundstat_serializer`, `smartcontracts_serializer`,
  `tokens_serializer`, `walletscache_serializer`,
  `walletsids_serializer`): `clear()` is in-memory only;
  `(void)rootDir` to silence unused-parameter warning;
  selected trace logging in `blockchain_serializer`.
- `csnode/include/csnode/walletsids.hpp`: `getNextId()` accessor.
- `client/config/config.hpp`, `client/config/config.cpp`:
  `StorageData` struct and `[storage]` parser.
- `csnode/src/walletscache.cpp`,
  `csnode/src/blockvalidatorplugins.cpp`,
  `csnode/src/multiwallets.cpp`,
  `csnode/src/poolcache.cpp`,
  `csnode/include/csnode/poolcache.hpp`: paired correctness fixes.
