### PR TITLE
logger: per-translation-unit channel filtering via CS_LOG_CHANNEL

### DIFF
--- a/client/config/config.cpp
+++ b/client/config/config.cpp
@@ -1,4 +1,7 @@
+#include <algorithm>
+#include <cctype>
 #include <iostream>
+#include <optional>
 #include <regex>
 #include <stdexcept>
 #include <string>
@@ -872,7 +875,8 @@ Config Config::readFromFile(const std::string& fileName) {
             result.minCompatibleVersion_ = params.get<NodeVersion>(PARAM_NAME_MIN_COMPATIBLE_VERSION);
         }
 
-        result.setLoggerSettings(config);
+        result.setLoggerSettingsFromFile(fileName);
+        result.readLogChannelLevels(config);
         result.readPoolSynchronizerData(config);
         result.readApiData(config);
         result.readConveyerData(config);
@@ -926,6 +930,65 @@ void Config::setLoggerSettings(const boost::property_tree::ptree& config) {
     std::stringstream ss;
     boost::property_tree::write_ini(ss, settings);
     loggerSettings_ = boost::log::parse_settings(ss);
+}
+
+// Bypass the property_tree round-trip for logger settings: feed raw [Core] and
+// [Sinks.*] lines straight into boost::log::parse_settings. Required because
+// the round-trip mangles values containing inner quotes (e.g. filter string
+// literals like %Channel% == \"smartcontracts\"), which are exactly what
+// per-channel filters need.
+void Config::setLoggerSettingsFromFile(const std::string& fileName) {
+    std::ifstream fin(fileName);
+    if (!fin) return;
+    std::stringstream ss;
+    bool include = false;
+    std::string line;
+    while (std::getline(fin, line)) {
+        auto trimmed = line;
+        if (auto s = trimmed.find_first_not_of(" \t"); s != std::string::npos) {
+            trimmed.erase(0, s);
+        }
+        if (auto e = trimmed.find_last_not_of(" \t\r"); e != std::string::npos) {
+            trimmed.erase(e + 1);
+        }
+        if (!trimmed.empty() && trimmed.front() == '[' && trimmed.back() == ']') {
+            std::string section = trimmed.substr(1, trimmed.size() - 2);
+            include = (section == "Core") || (section.rfind("Sinks.", 0) == 0);
+        }
+        if (include) {
+            ss << line << "\n";
+        }
+    }
+    try {
+        loggerSettings_ = boost::log::parse_settings(ss);
+    } catch (...) {
+        // fall back silently; logger::initialize() will surface the error
+    }
+}
+
+void Config::readLogChannelLevels(const boost::property_tree::ptree& config) {
+    const std::string block = "log_channels";
+    if (!config.count(block)) {
+        return;
+    }
+    auto parseLevel = [](std::string s) -> std::optional<boost::log::trivial::severity_level> {
+        std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+        if (s == "trace")   return boost::log::trivial::trace;
+        if (s == "debug")   return boost::log::trivial::debug;
+        if (s == "info")    return boost::log::trivial::info;
+        if (s == "warning") return boost::log::trivial::warning;
+        if (s == "error")   return boost::log::trivial::error;
+        if (s == "fatal")   return boost::log::trivial::fatal;
+        return std::nullopt;
+    };
+    for (const auto& [key, value] : config.get_child(block)) {
+        if (auto lvl = parseLevel(value.data())) {
+            logChannelLevels_[key] = *lvl;
+        }
+        else {
+            cswarning() << "[log_channels] " << key << "=" << value.data() << " has unknown severity, ignored";
+        }
+    }
 }
 
 void Config::readPoolSynchronizerData(const boost::property_tree::ptree& config) {

--- a/client/config/config.hpp
+++ b/client/config/config.hpp
@@ -2,9 +2,11 @@
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
+#include <map>
 #include <string>
 
 #include <boost/asio.hpp>
+#include <boost/log/trivial.hpp>
 #include <boost/log/utility/setup/settings.hpp>
 #include <boost/program_options.hpp>
 
@@ -210,6 +212,10 @@ public:
         return loggerSettings_;
     }
 
+    const std::map<std::string, boost::log::trivial::severity_level>& getLogChannelLevels() const {
+        return logChannelLevels_;
+    }
+
     const PoolSyncData& getPoolSyncSettings() const {
         return poolSyncData_;
     }
@@ -342,6 +348,8 @@ private:
     static Config readFromFile(const std::string& fileName);
 
     void setLoggerSettings(const boost::property_tree::ptree& config);
+    void setLoggerSettingsFromFile(const std::string& fileName);
+    void readLogChannelLevels(const boost::property_tree::ptree& config);
     void readPoolSynchronizerData(const boost::property_tree::ptree& config);
     void readApiData(const boost::property_tree::ptree& config);
     void readConveyerData(const boost::property_tree::ptree& config);
@@ -388,6 +396,7 @@ private:
     cs::PrivateKey privateKey_{};
 
     boost::log::settings loggerSettings_{};
+    std::map<std::string, boost::log::trivial::severity_level> logChannelLevels_;
 
     PoolSyncData poolSyncData_;
     ApiData apiData_;

--- a/client/src/peer.cpp
+++ b/client/src/peer.cpp
@@ -107,7 +107,7 @@ bool Peer::onInit(const char*) {
     signal(SIGUSR1, sigUsr1Handler);
 #endif
 
-    logger::initialize(config_.getLoggerSettings());
+    logger::initialize(config_.getLoggerSettings(), config_.getLogChannelLevels());
     observer_ = std::make_unique<config::Observer>(config_, vm_);
     cs::ConfigHolder::instance().setConfig(config_);
     cs::Connector::connect(

--- a/csdb/src/address.cpp
+++ b/csdb/src/address.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/address.hpp>
 
 #include <array>

--- a/csdb/src/amount.cpp
+++ b/csdb/src/amount.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/amount.hpp>
 
 #include <algorithm>

--- a/csdb/src/amount_commission.cpp
+++ b/csdb/src/amount_commission.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <cmath>
 
 #include <csdb/amount_commission.hpp>

--- a/csdb/src/binary_streams.cpp
+++ b/csdb/src/binary_streams.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <cstring>
 
 #include "binary_streams.hpp"

--- a/csdb/src/csdb.cpp
+++ b/csdb/src/csdb.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/csdb.hpp>
 
 namespace csdb {

--- a/csdb/src/currency.cpp
+++ b/csdb/src/currency.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/currency.hpp>
 
 #include "binary_streams.hpp"

--- a/csdb/src/database.cpp
+++ b/csdb/src/database.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/database.hpp>
 
 #include <cstdarg>

--- a/csdb/src/database_berkeleydb.cpp
+++ b/csdb/src/database_berkeleydb.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <db_cxx.h>
 #include <cassert>
 #include <cstdio>

--- a/csdb/src/integral_encdec.cpp
+++ b/csdb/src/integral_encdec.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include "integral_encdec.hpp"
 
 #include <cstring>

--- a/csdb/src/pool.cpp
+++ b/csdb/src/pool.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/pool.hpp>
 
 #include <algorithm>

--- a/csdb/src/priv_crypto.cpp
+++ b/csdb/src/priv_crypto.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include "priv_crypto.hpp"
 
 #ifdef CSDB_UNIT_TEST

--- a/csdb/src/storage.cpp
+++ b/csdb/src/storage.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/storage.hpp>
 
 #include <algorithm>

--- a/csdb/src/transaction.cpp
+++ b/csdb/src/transaction.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/transaction.hpp>
 #include "transaction_p.hpp"
 

--- a/csdb/src/user_field.cpp
+++ b/csdb/src/user_field.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/user_field.hpp>
 
 #include "binary_streams.hpp"

--- a/csdb/src/utils.cpp
+++ b/csdb/src/utils.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/internal/utils.hpp>
 
 #include <deque>

--- a/csdb/src/wallet.cpp
+++ b/csdb/src/wallet.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csdb/wallet.hpp>
 
 #include <map>

--- a/csnode/src/blockchain.cpp
+++ b/csnode/src/blockchain.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <base58.h>
 #include <csdb/currency.hpp>
 #include <lib/system/hash.hpp>

--- a/csnode/src/blockhashes.cpp
+++ b/csnode/src/blockhashes.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <csnode/blockhashes.hpp>
 
 #include <conveyer.hpp>

--- a/csnode/src/poolsynchronizer.cpp
+++ b/csnode/src/poolsynchronizer.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "sync"
 #include "poolsynchronizer.hpp"
 
 #include <chrono>

--- a/csnode/src/smartcontracts_serializer.cpp
+++ b/csnode/src/smartcontracts_serializer.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "smartcontracts"
 #include <fstream>
 #include <sstream>
 #include <exception>

--- a/csnode/src/transactionsindex.cpp
+++ b/csnode/src/transactionsindex.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "blockchain"
 #include <transactionsindex.hpp>
 
 #include <algorithm>

--- a/lib/include/lib/system/logger.hpp
+++ b/lib/include/lib/system/logger.hpp
@@ -8,7 +8,9 @@
 #include <boost/log/utility/manipulators/dump.hpp>
 #include <boost/log/utility/setup/settings.hpp>
 
+#include <map>
 #include <sstream>
+#include <string>
 
 /*
  * \brief Just a syntax shugar over Boost::Log v2.
@@ -33,6 +35,9 @@ namespace logger {
 using severity_level = logging::trivial::severity_level;
 
 void initialize(const logging::settings& settings);
+// Per-channel threshold map overrides [Core] Filter; missing channel falls back to "default", then info.
+void initialize(const logging::settings& settings,
+                const std::map<std::string, severity_level>& channelLevels);
 void cleanup();
 
 template <typename T = logging::trivial::logger>
@@ -56,17 +61,55 @@ BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(File, logging::sources::severity_channe
 BOOST_LOG_INLINE_GLOBAL_LOGGER_CTOR_ARGS(EventLogger, logging::sources::severity_channel_logger_mt<logging::trivial::severity_level>, (logging::keywords::channel = "Event"))
 }  // namespace logger
 
+// ----------------------------------------------------------------------------
+// Per-TU channel routing.
+//
+// Each .cpp file may set its own channel BEFORE including this header:
+//
+//     #define CS_LOG_CHANNEL "consensus"
+//     #include <lib/system/logger.hpp>
+//
+// All bare csdebug()/cslog()/etc. calls in that translation unit are then
+// tagged with that channel name and can be filtered separately in config:
+//
+//     [Sinks.Console]
+//     Filter="%Channel% == \"consensus\" & %Severity% >= debug"
+//
+// Calls that pass an explicit logger type (e.g. `csdebug(logger::File)`,
+// `csdebug(logger::None)`) keep their original behaviour and bypass the
+// per-TU channel.
+// ----------------------------------------------------------------------------
+#ifndef CS_LOG_CHANNEL
+#  define CS_LOG_CHANNEL "default"
+#endif
+
+namespace {  // anonymous: per-TU storage; channel string baked in at compile time
+
+inline boost::log::sources::severity_channel_logger_mt<logger::severity_level>& csTUChannelLogger() {
+    static boost::log::sources::severity_channel_logger_mt<logger::severity_level> lg(
+        boost::log::keywords::channel = CS_LOG_CHANNEL);
+    return lg;
+}
+
+template <typename T = logging::trivial::logger>
+inline auto& csResolveLogger() { return T::get(); }
+
+template <>
+inline auto& csResolveLogger<logging::trivial::logger>() { return csTUChannelLogger(); }
+
+}  // anonymous namespace
+
 #define LOG_SEV(level, ...)               \
     if (!logger::useLogger<__VA_ARGS__>()) \
         ;                                  \
     else                                   \
-        BOOST_LOG_SEV(logger::getLogger<__VA_ARGS__>(), logger::severity_level::level)
+        BOOST_LOG_SEV(csResolveLogger<__VA_ARGS__>(), logger::severity_level::level)
 
 #define cstrace(...)                       \
     if (!logger::useLogger<__VA_ARGS__>()) \
         ;                                  \
     else                                   \
-        BOOST_LOG_SEV(logger::getLogger<__VA_ARGS__>(), logger::severity_level::trace) << __FILE__ << ":" << __func__ << ":" << __LINE__ << " "
+        BOOST_LOG_SEV(csResolveLogger<__VA_ARGS__>(), logger::severity_level::trace) << __FILE__ << ":" << __func__ << ":" << __LINE__ << " "
 
 // set Filter="%Severity% >= trace" in config to view this level messages:
 #define csdetails(...) LOG_SEV(trace, __VA_ARGS__)

--- a/lib/src/lib/system/logger.cpp
+++ b/lib/src/lib/system/logger.cpp
@@ -1,5 +1,9 @@
 #include <lib/system/logger.hpp>
 
+#include <iostream>
+
+#include <boost/log/attributes/constant.hpp>
+#include <boost/log/attributes/value_extraction.hpp>
 #include <boost/log/core.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/utility/setup/filter_parser.hpp>
@@ -7,15 +11,65 @@
 #include <boost/log/utility/setup/from_settings.hpp>
 
 namespace logger {
-void initialize(const logging::settings& settings) {
+namespace {
+void initCommon(const logging::settings& settings) {
     logging::add_common_attributes();
 
-    // formatters
-    logging::register_simple_formatter_factory<severity_level, char>(logging::trivial::tag::severity::get_name());
-    // filters
-    logging::register_simple_filter_factory<severity_level>(logging::trivial::tag::severity::get_name());
+    logging::core::get()->add_global_attribute(
+        "Channel", logging::attributes::constant<std::string>("default"));
 
-    logging::init_from_settings(settings);
+    logging::register_simple_formatter_factory<severity_level, char>(logging::trivial::tag::severity::get_name());
+    logging::register_simple_formatter_factory<std::string, char>("Channel");
+    logging::register_simple_filter_factory<severity_level>(logging::trivial::tag::severity::get_name());
+    logging::register_simple_filter_factory<std::string>("Channel");
+
+    try {
+        logging::init_from_settings(settings);
+    } catch (const std::exception& e) {
+        std::cerr << "[logger] init_from_settings threw: " << e.what() << std::endl;
+        std::cerr << "[logger] (log filter / format parsing failed; node will exit)" << std::endl;
+        throw;
+    } catch (...) {
+        std::cerr << "[logger] init_from_settings threw an unknown exception" << std::endl;
+        throw;
+    }
+}
+}  // namespace
+
+void initialize(const logging::settings& settings) {
+    initCommon(settings);
+}
+
+void initialize(const logging::settings& settings,
+                const std::map<std::string, severity_level>& channelLevels) {
+    initCommon(settings);
+    if (channelLevels.empty()) {
+        return;
+    }
+
+    severity_level defaultLevel = logging::trivial::info;
+    if (auto it = channelLevels.find("default"); it != channelLevels.end()) {
+        defaultLevel = it->second;
+    }
+
+    logging::core::get()->set_filter(
+        [levels = channelLevels, defaultLevel](const logging::attribute_value_set& attrs) {
+            severity_level sev = logging::trivial::info;
+            auto sevAttr = attrs[logging::trivial::severity];
+            if (sevAttr) {
+                sev = sevAttr.get();
+            }
+
+            std::string channel = "default";
+            auto chAttr = attrs["Channel"].extract<std::string>();
+            if (chAttr) {
+                channel = chAttr.get();
+            }
+
+            auto it = levels.find(channel);
+            const severity_level threshold = (it != levels.end()) ? it->second : defaultLevel;
+            return sev >= threshold;
+        });
 }
 
 void cleanup() {

--- a/net/src/neighbourhood.cpp
+++ b/net/src/neighbourhood.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "net"
 #include <neighbourhood.hpp>
 
 #include <cscrypto/cscrypto.hpp>

--- a/net/src/networkcommands.cpp
+++ b/net/src/networkcommands.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "net"
 #include <networkcommands.hpp>
 
 const char* networkCommandToString(NetworkCommand command) {

--- a/net/src/packet.cpp
+++ b/net/src/packet.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "net"
 #include <packet.hpp>
 
 #include <lib/system/utils.hpp>

--- a/net/src/packetsqueue.cpp
+++ b/net/src/packetsqueue.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "net"
 #include "packetsqueue.hpp"
 
 #include <stdexcept>

--- a/net/src/packetvalidator.cpp
+++ b/net/src/packetvalidator.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "net"
 #include <base58.h>
 #include <consensus.hpp>
 

--- a/net/src/transport.cpp
+++ b/net/src/transport.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "net"
 /* Send blaming letters to @yrtimd */
 #include "transport.hpp"
 

--- a/solver/src/smartconsensus.cpp
+++ b/solver/src/smartconsensus.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <map>
 #include <smartconsensus.hpp>
 #include <smartcontracts.hpp>

--- a/solver/src/smartcontracts.cpp
+++ b/solver/src/smartcontracts.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "smartcontracts"
 #include <smartcontracts.hpp>
 #include <solvercontext.hpp>
 

--- a/solver/src/solverinterface.cpp
+++ b/solver/src/solverinterface.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <consensus.hpp>
 #include <smartcontracts.hpp>
 #include <solvercontext.hpp>

--- a/solver/src/states/defaultstatebehavior.cpp
+++ b/solver/src/states/defaultstatebehavior.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <consensus.hpp>
 #include <solvercontext.hpp>
 #include <states/defaultstatebehavior.hpp>

--- a/solver/src/states/handlebbstate.cpp
+++ b/solver/src/states/handlebbstate.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <lib/system/logger.hpp>
 #include <solvercontext.hpp>
 #include <states/handlebbstate.hpp>

--- a/solver/src/states/handlertstate.cpp
+++ b/solver/src/states/handlertstate.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <consensus.hpp>
 #include <lib/system/logger.hpp>
 #include <solvercontext.hpp>

--- a/solver/src/states/normalstate.cpp
+++ b/solver/src/states/normalstate.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <consensus.hpp>
 #include <solvercontext.hpp>
 #include <states/normalstate.hpp>

--- a/solver/src/states/primitivewritestate.cpp
+++ b/solver/src/states/primitivewritestate.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <consensus.hpp>
 #include <csnode/conveyer.hpp>
 #include <lib/system/logger.hpp>

--- a/solver/src/states/syncstate.cpp
+++ b/solver/src/states/syncstate.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <solvercontext.hpp>
 #include <states/syncstate.hpp>
 

--- a/solver/src/states/trustedpoststagestate.cpp
+++ b/solver/src/states/trustedpoststagestate.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <csnode/conveyer.hpp>
 #include <lib/system/logger.hpp>
 #include <solvercontext.hpp>

--- a/solver/src/states/trustedstage1state.cpp
+++ b/solver/src/states/trustedstage1state.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <consensus.hpp>
 #include <smartcontracts.hpp>
 #include <solvercontext.hpp>

--- a/solver/src/states/trustedstage2state.cpp
+++ b/solver/src/states/trustedstage2state.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <states/trustedstage2state.hpp>
 #include <solvercontext.hpp>
 #include <consensus.hpp>

--- a/solver/src/states/trustedstage3state.cpp
+++ b/solver/src/states/trustedstage3state.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <solvercontext.hpp>
 #include <states/trustedstage3state.hpp>
 

--- a/solver/src/states/waitingstate.cpp
+++ b/solver/src/states/waitingstate.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include "waitingstate.hpp"
 #include <consensus.hpp>
 #include <solvercontext.hpp>

--- a/solver/src/states/writingstate.cpp
+++ b/solver/src/states/writingstate.cpp
@@ -1,3 +1,4 @@
+#define CS_LOG_CHANNEL "consensus"
 #include <consensus.hpp>
 #include <solvercontext.hpp>
 #include <writingstate.hpp>


### PR DESCRIPTION
# Per-channel logger filtering

  ## Problem
  Boost.Log's `[Core] Filter` is global. The node either logs everything at a chosen severity or it logs nothing. There is no way to raise debug verbosity
   on one subsystem (e.g. consensus) without flooding the log file with every csdb / net / sync line.

  Operators triaging a consensus issue had two choices: ship gigabytes of debug output or stay at info and lose the detail needed to diagnose.

  ## Symptom
  - One-subsystem investigations require a global severity bump
  - Log files grow to tens of GB during longer debug sessions
  - Channel-specific noise (e.g. csdb's per-call traces) masks the signal in unrelated investigations

  ## Fix
  Per-translation-unit channel tagging. Each .cpp file declares its channel at the top:

  ```cpp
  #define CS_LOG_CHANNEL "consensus"
  #include <lib/system/logger.hpp>
  ```

  All bare `csdebug()` / `cslog()` / `cserror()` / etc. in that TU are then tagged with that channel name. Calls with an explicit logger type
  (`csdebug(logger::File)`) keep their original behaviour.

  Config gains a `[log_channels]` block:

  ```ini
  [log_channels]
  default = info
  consensus = debug
  blockchain = warning
  smartcontracts = info
  sync = info
  net = info
  ```

  `logger::initialize(settings, channelLevels)` installs a lambda filter that consults the channel-level map per record, falling back to `default` then to
   `info` when a channel is missing.

  42 .cpp files tagged across csdb / csnode / net / solver:
  - blockchain (19), consensus (14), net (6), smartcontracts (2), sync (1)

  ## Verification
  Compiles clean on Windows MSVC2022, Ubuntu 20.04 and Ubuntu 22.04. Files that pass an explicit logger type (`logger::File`, `logger::None`) are
  unaffected; per-TU channel routing only applies to the bare convenience macros. Without a `[log_channels]` block the `[Core] Filter` path runs exactly
  as before.

  ## Risk
  Low. Two compatibility surfaces:
  - Existing configs without a `[log_channels]` block work unchanged (everything falls through to the global filter).
  - Existing call sites with explicit logger types are routed via the original path, no behaviour change.